### PR TITLE
Improve the login process to make it could work for saas env

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
@@ -40,6 +40,10 @@ public final class AuthenticationTool {
 
     private static List<Authenticator> authenticators;
 
+    private AuthenticationTool() {
+        // Add the private constructor to hide the implicit public one.
+    }
+
     static {
         authenticators = new ArrayList<>();
         authenticators.add(new RestAuthenticator());

--- a/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
@@ -38,8 +38,15 @@ import java.util.List;
  */
 public final class AuthenticationTool {
 
-    private AuthenticationTool() {
-        //Hide the public constructor.
+    private static List<Authenticator> authenticators;
+
+    static {
+        authenticators = new ArrayList<>();
+        authenticators.add(new RestAuthenticator());
+        /**
+         * Mute RestAuthenticatorSaas for it's redundant after the improvement of RestAuthenticator.
+         * authenticators.add(new RestAuthenticatorSaas());
+         */
     }
 
     /**
@@ -54,10 +61,6 @@ public final class AuthenticationTool {
     }
 
     private static boolean login(Client client, String username, String password, String url, Logger logger) {
-        List<Authenticator> authenticators = new ArrayList<>();
-        authenticators.add(new RestAuthenticator());
-        authenticators.add(new RestAuthenticatorSaas());
-
         boolean result = false;
         for(Authenticator authenticator : authenticators) {
             try {

--- a/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
@@ -81,11 +81,11 @@ public final class AuthenticationTool {
         Response response =
                 client.httpPost(
                         client.build("rest/site-session"),
-                        null,
+                        new byte[1],    // For some server would require post request has a Content-Length.
                         null,
                         ResourceAccessLevel.PUBLIC);
         if (!response.isOk()) {
-            throw new SSEException("Cannot appned QCSession cookies", response.getFailure());
+            throw new SSEException("Cannot append QCSession cookies", response.getFailure());
         }
     }
 }

--- a/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/RestAuthenticator.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/RestAuthenticator.java
@@ -24,6 +24,7 @@ package com.hpe.application.automation.tools.sse.sdk.authenticator;
 
 import java.net.HttpURLConnection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.hpe.application.automation.tools.common.SSEException;
@@ -76,14 +77,12 @@ public class RestAuthenticator implements Authenticator {
      *         cookies for further use)
      */
     private Response login(Client client, String loginUrl, String username, String password) {
-        
         // create a string that looks like:
         // "Basic ((username:password)<as bytes>)<64encoded>"
         byte[] credBytes = (username + ":" + password).getBytes();
         String credEncodedString = "Basic " + Base64Encoder.encode(credBytes);
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(RESTConstants.AUTHORIZATION, credEncodedString);
-        
         return client.httpGet(loginUrl, null, headers, ResourceAccessLevel.PUBLIC);
     }
     
@@ -93,7 +92,6 @@ public class RestAuthenticator implements Authenticator {
      *             close session on server and clean session cookies on client
      */
     public boolean logout(Client client, String username) {
-        
         // note the get operation logs us out by setting authentication cookies to:
         // LWSSO_COOKIE_KEY="" via server response header Set-Cookie
         Response response =
@@ -104,18 +102,15 @@ public class RestAuthenticator implements Authenticator {
                         ResourceAccessLevel.PUBLIC);
         
         return response.isOk();
-        
     }
-    
+
     /**
-     * @return null if authenticated.<br>
-     *         a URL to authenticate against if not authenticated.
-     * @throws Exception
-     *             if error such as 404, or 500
+     * Verify is the client is already authenticated. If not, try get the authenticate point.
+     * @param client client
+     * @param logger logger
+     * @return null or authenticate point
      */
     private String isAuthenticated(Client client, Logger logger) {
-        
-        String ret;
         Response response =
                 client.httpGet(
                         client.build(IS_AUTHENTICATED),
@@ -124,25 +119,28 @@ public class RestAuthenticator implements Authenticator {
                         ResourceAccessLevel.PUBLIC);
         int responseCode = response.getStatusCode();
         
-
         if (isAlreadyAuthenticated(response, client.getUsername())) {
-            // already authenticated
-            ret = null;
             logLoggedInSuccessfully(client.getUsername(), client.getServerUrl(), logger);
-
-        } else if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
-            // if not authenticated - get the address where to authenticate via WWW-Authenticate
-            String newUrl = response.getHeaders().get(AUTHENTICATE_HEADER).get(0).split("=")[1];
-            newUrl = newUrl.replace("\"", "");
-            newUrl += "/authenticate";
-            ret = newUrl;
-
-        } else {
-            // error such as 404, or 500
-            throw new SSEException(response.getFailure());
+            return null;
         }
-        
-        return ret;
+
+        // Try to get authenticate point regardless the response status.
+        String authenticatePoint = getAuthenticatePoint(response);
+        if (authenticatePoint == null) {
+            // If can't get authenticate point, then output the message.
+            logger.log("Can't get authenticate header.");
+            if(responseCode != HttpURLConnection.HTTP_OK) {
+                try {
+                    throw new SSEException(response.getFailure());
+                } catch (Throwable e) {
+                    throw new SSEException(e);
+                }
+            }
+        } else {
+            authenticatePoint = authenticatePoint.replace("\"", "");
+            authenticatePoint += "/authenticate";
+        }
+        return authenticatePoint;
     }
     
     private boolean isAlreadyAuthenticated(Response response, String authUser) {
@@ -156,6 +154,27 @@ public class RestAuthenticator implements Authenticator {
         }
         
         return ret;
+    }
+
+    /**
+     * Try get authenticate point from response.
+     * @param response response
+     * @return null or authenticate point
+     */
+    private String getAuthenticatePoint(Response response) {
+        Map<String, List<String>> headers = response.getHeaders();
+        if (headers == null || headers.size() == 0) {
+            return null;
+        }
+        if (headers.get(AUTHENTICATE_HEADER) == null || headers.get(AUTHENTICATE_HEADER).size() == 0) {
+            return null;
+        }
+        String authenticateHeader = headers.get(AUTHENTICATE_HEADER).get(0);
+        String[] authenticateHeaderArray = authenticateHeader.split("=");
+        if (authenticateHeaderArray.length == 1) {
+            return null;
+        }
+        return authenticateHeaderArray[1];
     }
 
     //if it's authenticated, the response should look like that:

--- a/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/RestAuthenticator.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/RestAuthenticator.java
@@ -117,7 +117,6 @@ public class RestAuthenticator implements Authenticator {
                         null,
                         null,
                         ResourceAccessLevel.PUBLIC);
-        int responseCode = response.getStatusCode();
         
         if (isAlreadyAuthenticated(response, client.getUsername())) {
             logLoggedInSuccessfully(client.getUsername(), client.getServerUrl(), logger);
@@ -129,12 +128,8 @@ public class RestAuthenticator implements Authenticator {
         if (authenticatePoint == null) {
             // If can't get authenticate point, then output the message.
             logger.log("Can't get authenticate header.");
-            if(responseCode != HttpURLConnection.HTTP_OK) {
-                try {
-                    throw new SSEException(response.getFailure());
-                } catch (Throwable e) {
-                    throw new SSEException(e);
-                }
+            if(response.getStatusCode() != HttpURLConnection.HTTP_OK) {
+                throw new SSEException(response.getFailure());
             }
         } else {
             authenticatePoint = authenticatePoint.replace("\"", "");
@@ -166,7 +161,7 @@ public class RestAuthenticator implements Authenticator {
         if (headers == null || headers.size() == 0) {
             return null;
         }
-        if (headers.get(AUTHENTICATE_HEADER) == null || headers.get(AUTHENTICATE_HEADER).size() == 0) {
+        if (headers.get(AUTHENTICATE_HEADER) == null || headers.get(AUTHENTICATE_HEADER).isEmpty()) {
             return null;
         }
         String authenticateHeader = headers.get(AUTHENTICATE_HEADER).get(0);


### PR DESCRIPTION
1.Improve the login process to make it could work for saas env. We will consider is-authenticate as pass as long as it gets authenticate point.
2.Site session accept post request but the request contains no content. Some server refuses this and requires a content-length header.