### PR TITLE
Octane & BDI updates & Fixes for 5.2.0.2-beta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.12</version>
+			<version>1.4.13</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->

--- a/pom.xml
+++ b/pom.xml
@@ -386,14 +386,14 @@
 		<dependency>
 			<artifactId>integrations-sdk</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.4</version>
+			<version>1.4.7</version>
 		</dependency>
 
 		<!-- Obsolete TO BE REMOVED -->
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.13</version>
+			<version>1.4.14</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->

--- a/src/main/java/com/hpe/application/automation/tools/model/PcModel.java
+++ b/src/main/java/com/hpe/application/automation/tools/model/PcModel.java
@@ -14,7 +14,7 @@ public class PcModel {
     public static final String    COLLATE_ANALYZE = "Collate and Analyze";
     public static final String    DO_NOTHING      = "Do Not Collate";
 
-    private final String           serverandport;
+    private final String           serverAndPort;
     private final String           pcServerName;
     private final String           almUserName;
     private final SecretContainer  almPassword;
@@ -34,11 +34,11 @@ public class PcModel {
 
 
     @DataBoundConstructor
-    public PcModel(String serverandport, String pcServerName, String almUserName, String almPassword, String almDomain, String almProject,
+    public PcModel(String serverAndPort, String pcServerName, String almUserName, String almPassword, String almDomain, String almProject,
                    String testId,String autoTestInstanceID, String testInstanceId, String timeslotDurationHours, String timeslotDurationMinutes,
                    PostRunAction postRunAction, boolean vudsMode, String description, String addRunToTrendReport, String trendReportId, boolean HTTPSProtocol, String proxyOutURL) {
 
-        this.serverandport = serverandport;
+        this.serverAndPort = serverAndPort;
         this.pcServerName = pcServerName;
         this.almUserName = almUserName;
         this.almPassword = setPassword(almPassword);
@@ -64,8 +64,8 @@ public class PcModel {
         return secretContainer;
     }
 
-    public String getserverandport(){
-        return this.serverandport;
+    public String getserverAndPort(){
+        return this.serverAndPort;
     }
 
     public String getPcServerName() {

--- a/src/main/java/com/hpe/application/automation/tools/model/PcModel.java
+++ b/src/main/java/com/hpe/application/automation/tools/model/PcModel.java
@@ -14,6 +14,7 @@ public class PcModel {
     public static final String    COLLATE_ANALYZE = "Collate and Analyze";
     public static final String    DO_NOTHING      = "Do Not Collate";
 
+    private final String           serverandport;
     private final String           pcServerName;
     private final String           almUserName;
     private final SecretContainer  almPassword;
@@ -33,10 +34,11 @@ public class PcModel {
 
 
     @DataBoundConstructor
-    public PcModel(String pcServerName, String almUserName, String almPassword, String almDomain, String almProject,
+    public PcModel(String serverandport, String pcServerName, String almUserName, String almPassword, String almDomain, String almProject,
                    String testId,String autoTestInstanceID, String testInstanceId, String timeslotDurationHours, String timeslotDurationMinutes,
                    PostRunAction postRunAction, boolean vudsMode, String description, String addRunToTrendReport, String trendReportId, boolean HTTPSProtocol, String proxyOutURL) {
 
+        this.serverandport = serverandport;
         this.pcServerName = pcServerName;
         this.almUserName = almUserName;
         this.almPassword = setPassword(almPassword);
@@ -60,6 +62,10 @@ public class PcModel {
         SecretContainer secretContainer = new SecretContainerImpl();
         secretContainer.initialize(almPassword);
         return secretContainer;
+    }
+
+    public String getserverandport(){
+        return this.serverandport;
     }
 
     public String getPcServerName() {

--- a/src/main/java/com/hpe/application/automation/tools/octane/AbstractResultQueueImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/AbstractResultQueueImpl.java
@@ -31,6 +31,7 @@ import java.io.*;
 
 public abstract class AbstractResultQueueImpl implements ResultQueue {
 
+	private static final int RETRIES = 3;
 	private final int MAX_RETRIES;
 
 	private FileObjectQueue<QueueItem> queue;
@@ -38,7 +39,7 @@ public abstract class AbstractResultQueueImpl implements ResultQueue {
 	private QueueItem currentItem;
 
 	public AbstractResultQueueImpl() {
-		this.MAX_RETRIES = 3;
+		this.MAX_RETRIES = RETRIES;
 	}
 
 	public AbstractResultQueueImpl(int maxRetries) {

--- a/src/main/java/com/hpe/application/automation/tools/octane/CIJenkinsServicesImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/CIJenkinsServicesImpl.java
@@ -94,7 +94,8 @@ public class CIJenkinsServicesImpl extends CIPluginServicesBase {
                 .setUrl(serverUrl)
                 .setInstanceId(model.getIdentity())
                 .setInstanceIdFrom(model.getIdentityFrom())
-                .setSendingTime(System.currentTimeMillis());
+                .setSendingTime(System.currentTimeMillis())
+                .setImpersonatedUser(model.getImpersonatedUser());
         return result;
     }
 

--- a/src/main/java/com/hpe/application/automation/tools/octane/CIJenkinsServicesImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/CIJenkinsServicesImpl.java
@@ -177,7 +177,7 @@ public class CIJenkinsServicesImpl extends CIPluginServicesBase {
                             continue;
                         }
                         tmpConfig = dtoFactory.newDTO(PipelineNode.class)
-                                .setJobCiId(JobProcessorFactory.getFlowProcessor(abstractProject).getJobCiId())
+                                .setJobCiId(JobProcessorFactory.getFlowProcessor(abstractProject).getTranslateJobName())
                                 .setName(name);
                         if (includeParameters) {
                             tmpConfig.setParameters(ParameterProcessors.getConfigs(abstractProject));
@@ -186,7 +186,7 @@ public class CIJenkinsServicesImpl extends CIPluginServicesBase {
                     } else if (tmpItem.getClass().getName().equals("org.jenkinsci.plugins.workflow.job.WorkflowJob")) {
                         Job tmpJob = (Job) tmpItem;
                         tmpConfig = dtoFactory.newDTO(PipelineNode.class)
-                                .setJobCiId(JobProcessorFactory.getFlowProcessor(tmpJob).getJobCiId())
+                                .setJobCiId(JobProcessorFactory.getFlowProcessor(tmpJob).getTranslateJobName())
                                 .setName(name);
                         if (includeParameters) {
                             tmpConfig.setParameters(ParameterProcessors.getConfigs(tmpJob));
@@ -195,7 +195,7 @@ public class CIJenkinsServicesImpl extends CIPluginServicesBase {
                     } else if (tmpItem.getClass().getName().equals("com.cloudbees.hudson.plugins.folder.Folder")) {
                         for (Job tmpJob : tmpItem.getAllJobs()) {
                             tmpConfig = dtoFactory.newDTO(PipelineNode.class)
-                                    .setJobCiId(JobProcessorFactory.getFlowProcessor(tmpJob).getJobCiId())
+                                    .setJobCiId(JobProcessorFactory.getFlowProcessor(tmpJob).getTranslateJobName())
                                     .setName(tmpJob.getName());
                             if (includeParameters) {
                                 tmpConfig.setParameters(ParameterProcessors.getConfigs(tmpJob));

--- a/src/main/java/com/hpe/application/automation/tools/octane/bridge/BridgeClient.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/bridge/BridgeClient.java
@@ -80,7 +80,8 @@ public class BridgeClient {
 								pluginServices.getServerInfo().getType().value(),
 								pluginServices.getServerInfo().getUrl(),
 								OctaneSDK.API_VERSION,
-								OctaneSDK.SDK_VERSION);
+								OctaneSDK.SDK_VERSION,
+								OctaneSDK.getInstance().getPluginServices().getPluginInfo().getVersion());
 						isConnected = false;
 						connect();
 						if (tasksJSON != null && !tasksJSON.isEmpty()) {

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogDispatcher.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogDispatcher.java
@@ -28,6 +28,7 @@ import com.hpe.application.automation.tools.octane.client.RetryModel;
 import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
 import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
 import com.hpe.application.automation.tools.octane.tests.AbstractSafeLoggingAsyncPeriodWork;
+import com.hpe.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.Extension;
 import hudson.console.PlainTextConsoleOutputStream;
 import hudson.model.Job;
@@ -121,9 +122,9 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 					//
 					//  initial queue item flow - no workspaces, works with workspaces retrieval and loop ever each of them
 					//
-					List<String> workspaces = mqmRestClient.getJobWorkspaceId(ConfigurationService.getModel().getIdentity(), build.getParent().getName());
+					List<String> workspaces = mqmRestClient.getJobWorkspaceId(ConfigurationService.getModel().getIdentity(), BuildHandlerUtils.getJobCiId(build));
 					if (workspaces.isEmpty()) {
-						logger.info(String.format("Job '%s' is not part of an Octane pipeline in any workspace, so its log will not be sent.", build.getParent().getName()));
+						logger.info(String.format("Job '%s' is not part of an Octane pipeline in any workspace, so its log will not be sent.", BuildHandlerUtils.getJobCiId(build)));
 					} else {
 						CountDownLatch latch = new CountDownLatch(workspaces.size());
 
@@ -298,7 +299,7 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 				boolean status = mqmRestClient.postLogs(
 						parseLong(workspaceId),
 						ConfigurationService.getModel().getIdentity(),
-						build.getParent().getName(),
+						BuildHandlerUtils.getJobCiId(build),
 						String.valueOf(build.getNumber()),
 						octaneLog.getLogStream(),
 						octaneLog.getFileLength());

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogDispatcher.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogDispatcher.java
@@ -21,7 +21,10 @@ import com.google.inject.Inject;
 import com.hp.mqm.client.MqmRestClient;
 import com.hp.mqm.client.exception.RequestErrorException;
 import com.hpe.application.automation.tools.octane.ResultQueue;
-import com.hpe.application.automation.tools.octane.client.*;
+import com.hpe.application.automation.tools.octane.client.JenkinsInsightEventPublisher;
+import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactory;
+import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactoryImpl;
+import com.hpe.application.automation.tools.octane.client.RetryModel;
 import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
 import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
 import com.hpe.application.automation.tools.octane.tests.AbstractSafeLoggingAsyncPeriodWork;
@@ -37,7 +40,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
@@ -57,6 +63,10 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 
 	private static final String OCTANE_LOG_FILE_NAME = "octane_log";
 	private static final int MAX_RETRIES = 6;
+	private static final long TIMEOUT = 20;
+
+	private static final double BASE = 2;
+	private static final double EXPONENT = 0;
 
 	private RetryModel retryModel;
 	private JenkinsMqmRestClientFactory clientFactory;
@@ -68,11 +78,10 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 	}
 
 	private long[] getQuietPeriodsInMinutes(double retries) {
-		double base = 2;
-		double exponent = 0;
+		double exponent = EXPONENT;
 		List<Long> quietPeriods = new ArrayList<>();
 		while (exponent <= retries) {
-			quietPeriods.add(TimeUnit2.MINUTES.toMillis((long) Math.pow(base, exponent)));
+			quietPeriods.add(TimeUnit2.MINUTES.toMillis((long) Math.pow(BASE, exponent)));
 			exponent++;
 		}
 		return Longs.toArray(quietPeriods);
@@ -129,41 +138,48 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 							));
 						}
 
-						latch.await(20, TimeUnit.MINUTES);
+						boolean completedResult = latch.await(TIMEOUT, TimeUnit.MINUTES);
+						if (completedResult) {
+							logger.error("timed out sending logs to - " + workspaces.size() + " workspaces.");
+						}
 					}
 					logsQueue.remove();
 				} else {
 					//
 					//  secondary queue item flow - workspace is known, we are in retry flow
 					//
-					try {
-						OctaneLog octaneLog = getOctaneLogFile(build);
-						boolean status = mqmRestClient.postLogs(
-								parseLong(item.getWorkspace()),
-								ConfigurationService.getModel().getIdentity(),
-								build.getParent().getName(),
-								String.valueOf(build.getNumber()),
-								octaneLog.getLogStream(),
-								octaneLog.getFileLength());
-						if (status) {
-							logger.info("Successfully sent logs of " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace());
-							logsQueue.remove();
-						} else {
-							logger.error("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace());
-							reAttempt(item.getProjectName(), item.getBuildNumber());
-						}
-					} catch (RequestErrorException ree) {
-						logger.error("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace(), ree);
-						reAttempt(item.getProjectName(), item.getBuildNumber());
-					} catch (Exception e) {
-						logger.error("fatally failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace() + ", will not retry this one", e);
-						retryModel.success();
-						logsQueue.remove();
-					}
+					transferBuildLogs(build, mqmRestClient, item);
 				}
 			} catch (Exception e) {
 				logger.error("fatally failed to fetch relevant workspaces OR to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace() + ", will not retry this one", e);
 			}
+		}
+	}
+
+	private void transferBuildLogs(Run build, MqmRestClient mqmRestClient, ResultQueue.QueueItem item) {
+		try {
+			OctaneLog octaneLog = getOctaneLogFile(build);
+			boolean status = mqmRestClient.postLogs(
+					parseLong(item.getWorkspace()),
+					ConfigurationService.getModel().getIdentity(),
+					build.getParent().getName(),
+					String.valueOf(build.getNumber()),
+					octaneLog.getLogStream(),
+					octaneLog.getFileLength());
+			if (status) {
+				logger.info("Successfully sent logs of " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace());
+				logsQueue.remove();
+			} else {
+				logger.error("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace());
+				reAttempt(item.getProjectName(), item.getBuildNumber());
+			}
+		} catch (RequestErrorException ree) {
+			logger.error("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace(), ree);
+			reAttempt(item.getProjectName(), item.getBuildNumber());
+		} catch (Exception e) {
+			logger.error("fatally failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace() + ", will not retry this one", e);
+			retryModel.success();
+			logsQueue.remove();
 		}
 	}
 

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/RunListenerForLogs.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/RunListenerForLogs.java
@@ -44,8 +44,8 @@ public class RunListenerForLogs extends RunListener<Run> {
 	public void onCompleted(Run r, @Nonnull TaskListener listener) {
 		if (r instanceof AbstractBuild && ConfigurationService.getServerConfiguration().isValid()) {
 			AbstractBuild build = (AbstractBuild) r;
-			logger.info(String.format("Enqueued job [%s#%d]", build.getParent().getName(), build.getNumber()));
-			logDispatcher.enqueueLog(build.getProject().getName(), build.getNumber());
+			logger.info(String.format("Enqueued job [%s#%d]", build.getProject().getFullName(), build.getNumber()));
+			logDispatcher.enqueueLog(build.getProject().getFullName(), build.getNumber());
 		} else {
 			logger.warn("Octane configuration is not valid");
 		}

--- a/src/main/java/com/hpe/application/automation/tools/octane/client/RetryModel.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/client/RetryModel.java
@@ -25,10 +25,12 @@ import hudson.util.TimeUnit2;
 @Extension
 public class RetryModel implements ConfigurationListener {
 
+    private static final long[] QUIET_PERIOD_DURATION = { 1, 10, 60 };
+
     private long[] QUIET_PERIOD = {
-            TimeUnit2.MINUTES.toMillis(1),
-            TimeUnit2.MINUTES.toMillis(10),
-            TimeUnit2.MINUTES.toMillis(60)
+            TimeUnit2.MINUTES.toMillis(QUIET_PERIOD_DURATION[0]),
+            TimeUnit2.MINUTES.toMillis(QUIET_PERIOD_DURATION[1]),
+            TimeUnit2.MINUTES.toMillis(QUIET_PERIOD_DURATION[2])
     };
 
     private long boundary;

--- a/src/main/java/com/hpe/application/automation/tools/octane/configuration/JobConfigurationProxy.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/configuration/JobConfigurationProxy.java
@@ -154,7 +154,7 @@ public class JobConfigurationProxy {
 				fields.add(new ListField(jsonObject.getString("name"), assignedValues));
 			}
 
-            final String jobCiId = JobProcessorFactory.getFlowProcessor(job).getJobCiId();
+            final String jobCiId = JobProcessorFactory.getFlowProcessor(job).getTranslateJobName();
 
             Pipeline pipeline = client.updatePipeline(ConfigurationService.getModel().getIdentity(), jobCiId,
 					new Pipeline(pipelineId, pipelineObject.getString("name"), null, pipelineObject.getLong("workspaceId"), pipelineObject.getLong("releaseId"), taxonomies, fields, pipelineObject.getBoolean("ignoreTests")));
@@ -248,7 +248,7 @@ public class JobConfigurationProxy {
 			}
 			ret.put("isUftJob", isUftJob);
 
-            final String jobCiId = JobProcessorFactory.getFlowProcessor(job).getJobCiId();
+            final String jobCiId = JobProcessorFactory.getFlowProcessor(job).getTranslateJobName();
             JobConfiguration jobConfiguration = client.getJobConfiguration(ConfigurationService.getModel().getIdentity(), jobCiId);
 
 			if (!jobConfiguration.getWorkspacePipelinesMap().isEmpty()) {

--- a/src/main/java/com/hpe/application/automation/tools/octane/executor/CheckOutSubDirEnvContributor.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/executor/CheckOutSubDirEnvContributor.java
@@ -34,8 +34,9 @@ import java.io.IOException;
 @Extension
 public class CheckOutSubDirEnvContributor extends EnvironmentContributor {
 
-    public static String CHECKOUT_SUBDIR_ENV_NAME  = "CHECKOUT_SUBDIR";
+    public static final String CHECKOUT_SUBDIR_ENV_NAME  = "CHECKOUT_SUBDIR";
 
+    @Override
     public void buildEnvironmentFor(Job j, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
         String dir = getSharedCheckOutDirectory(j);
         if (dir != null) {

--- a/src/main/java/com/hpe/application/automation/tools/octane/executor/CheckOutSubDirEnvContributor.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/executor/CheckOutSubDirEnvContributor.java
@@ -1,0 +1,62 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.executor;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.impl.RelativeTargetDirectory;
+import hudson.scm.SCM;
+
+import java.io.IOException;
+
+/**
+ * Add job environment value for CHECKOUT_SUBDIR
+ */
+@Extension
+public class CheckOutSubDirEnvContributor extends EnvironmentContributor {
+
+    public static String CHECKOUT_SUBDIR_ENV_NAME  = "CHECKOUT_SUBDIR";
+
+    public void buildEnvironmentFor(Job j, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
+        String dir = getSharedCheckOutDirectory(j);
+        if (dir != null) {
+            envs.put(CHECKOUT_SUBDIR_ENV_NAME, dir);
+        }
+    }
+
+    public static String getSharedCheckOutDirectory(Job j) {
+        if (j instanceof FreeStyleProject) {
+            SCM scm = ((FreeStyleProject) j).getScm();
+            if (scm != null && scm instanceof GitSCM) {
+                GitSCM gitScm = (GitSCM) scm;
+                RelativeTargetDirectory sharedCheckOutDirectory = gitScm.getExtensions().get(RelativeTargetDirectory.class);
+                if (sharedCheckOutDirectory != null) {
+                    return sharedCheckOutDirectory.getRelativeTargetDir();
+                }
+            }
+
+        }
+        return null;
+    }
+
+}
+

--- a/src/main/java/com/hpe/application/automation/tools/octane/model/CIEventCausesFactory.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/model/CIEventCausesFactory.java
@@ -19,6 +19,7 @@ package com.hpe.application.automation.tools.octane.model;
 import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.causes.CIEventCause;
 import com.hp.octane.integrations.dto.causes.CIEventCauseType;
+import com.hpe.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.model.Cause;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
@@ -71,8 +72,8 @@ public final class CIEventCausesFactory {
 	}
 
 	private static String resolveJobCiId(String jobPlainName) {
-		if(jobPlainName.contains("/")  && !jobPlainName.contains(",")) {
-			return jobPlainName.replaceAll("/", "/job/");
+		if(!jobPlainName.contains(",")) {
+			return BuildHandlerUtils.translateFolderJobName(jobPlainName);
 		}
 		return jobPlainName;
 	}

--- a/src/main/java/com/hpe/application/automation/tools/octane/model/ModelFactory.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/model/ModelFactory.java
@@ -48,7 +48,7 @@ public class ModelFactory {
 	public static PipelineNode createStructureItem(Job job) {
 		AbstractProjectProcessor projectProcessor = JobProcessorFactory.getFlowProcessor(job);
 		PipelineNode pipelineNode = dtoFactory.newDTO(PipelineNode.class);
-		pipelineNode.setJobCiId(projectProcessor.getJobCiId());
+		pipelineNode.setJobCiId(projectProcessor.getTranslateJobName());
 		pipelineNode.setName(job.getName());
 		pipelineNode.setParameters(ParameterProcessors.getConfigs(job));
 		pipelineNode.setPhasesInternal(projectProcessor.getInternals());
@@ -137,7 +137,7 @@ public class ModelFactory {
 	public static SnapshotNode createSnapshotItem(Job project, boolean metaOnly) {
 		SnapshotNode snapshotNode = dtoFactory.newDTO(SnapshotNode.class);
 		AbstractProjectProcessor flowProcessor = JobProcessorFactory.getFlowProcessor(project);
-		snapshotNode.setJobCiId(flowProcessor.getJobCiId());
+		snapshotNode.setJobCiId(flowProcessor.getTranslateJobName());
 		snapshotNode.setName(project.getName());
 
 		if (!metaOnly) {

--- a/src/main/java/com/hpe/application/automation/tools/octane/model/processors/projects/AbstractProjectProcessor.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/model/processors/projects/AbstractProjectProcessor.java
@@ -21,6 +21,7 @@ import com.hpe.application.automation.tools.octane.model.processors.builders.Bui
 import com.hpe.application.automation.tools.octane.model.processors.builders.MultiJobBuilderProcessor;
 import com.hpe.application.automation.tools.octane.model.processors.builders.ParameterizedTriggerProcessor;
 import com.hp.octane.integrations.dto.pipelines.PipelinePhase;
+import com.hpe.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.tasks.BuildStep;
@@ -71,13 +72,14 @@ public abstract class AbstractProjectProcessor<T extends Job> {
 
     /**
      * Retrieve Job's CI ID
-     *
+     * return the job name, in case of a folder job, this method returns the refactored
+     * name that matches the required pattern.
      * @return Job's CI ID
      */
-    public String getJobCiId() {
+    public String getTranslateJobName() {
         if (job.getParent().getClass().getName().equals("com.cloudbees.hudson.plugins.folder.Folder")) {
             String jobPlainName = job.getFullName();    // e.g: myFolder/myJob
-            return jobPlainName.replaceAll("/", "/job/");
+            return BuildHandlerUtils.translateFolderJobName(jobPlainName);
         } else {
             return job.getName();
         }

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/build/BuildHandlerUtils.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/build/BuildHandlerUtils.java
@@ -81,12 +81,21 @@ public class BuildHandlerUtils {
 
 	public static String getJobCiId(Run r) {
 		if (r.getParent() instanceof MatrixConfiguration) {
-			return JobProcessorFactory.getFlowProcessor(((MatrixRun) r).getParentBuild().getParent()).getJobCiId();
+			return JobProcessorFactory.getFlowProcessor(((MatrixRun) r).getParentBuild().getParent()).getTranslateJobName();
 		}
 		if (r.getParent().getClass().getName().equals("org.jenkinsci.plugins.workflow.job.WorkflowJob")) {
-			return JobProcessorFactory.getFlowProcessor(r.getParent()).getJobCiId();
+			return JobProcessorFactory.getFlowProcessor(r.getParent()).getTranslateJobName();
 		}
-		return JobProcessorFactory.getFlowProcessor(((AbstractBuild) r).getProject()).getJobCiId();
+		return JobProcessorFactory.getFlowProcessor(((AbstractBuild) r).getProject()).getTranslateJobName();
 	}
 
+	/**
+	 * Retrieve Job's CI ID
+	 *
+	 * @return Job's CI ID
+	 */
+	public static String translateFolderJobName(String jobPlainName) {
+		String newSplitterCharacters = "/job/";
+		return jobPlainName.replaceAll("/", newSplitterCharacters);
+	}
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitExtension.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitExtension.java
@@ -18,6 +18,7 @@ package com.hpe.application.automation.tools.octane.tests.junit;
 
 import com.google.inject.Inject;
 import com.hpe.application.automation.tools.octane.actions.cucumber.CucumberTestResultsAction;
+import com.hpe.application.automation.tools.octane.executor.CheckOutSubDirEnvContributor;
 import com.hpe.application.automation.tools.octane.tests.HPRunnerType;
 import com.hpe.application.automation.tools.octane.tests.MqmTestsExtension;
 import com.hpe.application.automation.tools.octane.tests.TestResultContainer;
@@ -157,6 +158,7 @@ public class JUnitExtension extends MqmTestsExtension {
 		private long buildStarted;
 		private FilePath workspace;
 		private boolean stripPackageAndClass;
+		private String sharedCheckOutDirectory;
 
 		//this class is run on master and JUnitXmlIterator is runnning on slave.
 		//this object pass some master2slave data
@@ -172,7 +174,7 @@ public class JUnitExtension extends MqmTestsExtension {
 			this.hpRunnerType = hpRunnerType;
 			this.jenkinsRootUrl = jenkinsRootUrl;
 			this.buildRootDir = build.getRootDir().getCanonicalPath();
-
+			this.sharedCheckOutDirectory = CheckOutSubDirEnvContributor.getSharedCheckOutDirectory(build.getParent());
 
 			//AbstractProject project = (AbstractProject)build.getParent();/*build.getProject()*/;
 			this.jobName =build.getParent().getName();// project.getName();
@@ -209,7 +211,7 @@ public class JUnitExtension extends MqmTestsExtension {
 
 			try {
 				for (FilePath report : reports) {
-					JUnitXmlIterator iterator = new JUnitXmlIterator(report.read(), moduleDetection, workspace, jobName, buildId, buildStarted, stripPackageAndClass, hpRunnerType, jenkinsRootUrl, additionalContext);
+					JUnitXmlIterator iterator = new JUnitXmlIterator(report.read(), moduleDetection, workspace, sharedCheckOutDirectory, jobName, buildId, buildStarted, stripPackageAndClass, hpRunnerType, jenkinsRootUrl, additionalContext);
 					while (iterator.hasNext()) {
 						oos.writeObject(iterator.next());
 					}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
@@ -65,13 +65,15 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 	private String externalURL;
 	private List<ModuleDetection> moduleDetection;
 	private String jenkinsRootUrl;
+	private String sharedCheckOutDirectory;
 	private Object additionalContext;
 
-	public JUnitXmlIterator(InputStream read, List<ModuleDetection> moduleDetection, FilePath workspace, String jobName, String buildId, long buildStarted, boolean stripPackageAndClass, HPRunnerType hpRunnerType, String jenkinsRootUrl, Object additionalContext) throws XMLStreamException {
+	public JUnitXmlIterator(InputStream read, List<ModuleDetection> moduleDetection, FilePath workspace, String sharedCheckOutDirectory, String jobName, String buildId, long buildStarted, boolean stripPackageAndClass, HPRunnerType hpRunnerType, String jenkinsRootUrl, Object additionalContext) throws XMLStreamException {
 		super(read);
 		this.stripPackageAndClass = stripPackageAndClass;
 		this.moduleDetection = moduleDetection;
 		this.workspace = workspace;
+		this.sharedCheckOutDirectory = sharedCheckOutDirectory;
 		this.buildId = buildId;
 		this.jobName = jobName;
 		this.buildStarted = buildStarted;
@@ -160,7 +162,8 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 					if (testName.startsWith(workspace.getRemote())) {
 						// if workspace is prefix of the method name, cut it off
 						// currently this handling is needed for UFT tests
-						String path = testName.substring(workspace.getRemote().length());
+						int testStartIndex = workspace.getRemote().length() + (sharedCheckOutDirectory == null ? 0 : sharedCheckOutDirectory.length() +1 /*+ for slash between workspace and shared dir*/);
+						String path = testName.substring(testStartIndex);
 						path = path.replace(OctaneConstants.General.LINUX_PATH_SPLITTER, OctaneConstants.General.WINDOWS_PATH_SPLITTER);
 						path = StringUtils.strip(path, OctaneConstants.General.WINDOWS_PATH_SPLITTER);
 

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
@@ -142,7 +142,7 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 				errorMsg = "";
 			} else if ("className".equals(localName)) { // NON-NLS
 				String fqn = readNextValue();
-				int p = fqn.lastIndexOf(".");
+				int p = fqn.lastIndexOf('.');
 				className = fqn.substring(p + 1);
 				if (p > 0) {
 					packageName = fqn.substring(0, p);
@@ -162,7 +162,7 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 					if (testName.startsWith(workspace.getRemote())) {
 						// if workspace is prefix of the method name, cut it off
 						// currently this handling is needed for UFT tests
-						int testStartIndex = workspace.getRemote().length() + (sharedCheckOutDirectory == null ? 0 : sharedCheckOutDirectory.length() +1 /*+ for slash between workspace and shared dir*/);
+						int testStartIndex = workspace.getRemote().length() + (sharedCheckOutDirectory == null ? 0 : (sharedCheckOutDirectory.length() + 1));
 						String path = testName.substring(testStartIndex);
 						path = path.replace(OctaneConstants.General.LINUX_PATH_SPLITTER, OctaneConstants.General.WINDOWS_PATH_SPLITTER);
 						path = StringUtils.strip(path, OctaneConstants.General.WINDOWS_PATH_SPLITTER);
@@ -219,7 +219,7 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 			} else if ("errorDetails".equals(localName)) { // NON-NLS
 				status = TestResultStatus.FAILED;
 				errorMsg = readNextValue();
-				int index = stackTraceStr.indexOf(":");
+				int index = stackTraceStr.indexOf(':');
 				if (index >= 0) {
 					errorType = stackTraceStr.substring(0, index);
 				}
@@ -244,10 +244,10 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 	private String cleanTestName(String testName) {
 		// subfolder\testname
 		if (testName.contains("\\")) {
-			return testName.substring(testName.lastIndexOf("\\") + 1);
+			return testName.substring(testName.lastIndexOf('\\') + 1);
 		}
 		if (testName.contains("/")) {
-			return testName.substring(testName.lastIndexOf("/") + 1);
+			return testName.substring(testName.lastIndexOf('/') + 1);
 		}
 		return testName;
 	}

--- a/src/main/java/com/hpe/application/automation/tools/run/PcBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/PcBuilder.java
@@ -107,7 +107,7 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
     
     @DataBoundConstructor
     public PcBuilder(
-            String serverandport,
+            String serverAndPort,
             String pcServerName,
             String almUserName,
             String almPassword,
@@ -134,7 +134,7 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
 
         pcModel =
                 new PcModel(
-                        serverandport.trim(),
+                        serverAndPort.trim(),
                         pcServerName.trim(),
                         almUserName.trim(),
                         almPassword,
@@ -590,7 +590,7 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
         String downloadUrl = String.format(urlPattern + "/%s", "*zip*/pcRun");
         logger.println(HyperlinkNote.encodeTo(viewUrl, "View analysis report of run " + runId));
 
-        return String.format("Load Test Run ID: %s\n\nView analysis report:\n%s\n\nDownload Report:\n%s", runId, pcModel.getserverandport() +  "/" +  build.getUrl() + viewUrl, pcModel.getserverandport() + "/" + build.getUrl() + downloadUrl);
+        return String.format("Load Test Run ID: %s\n\nView analysis report:\n%s\n\nDownload Report:\n%s", runId, pcModel.getserverAndPort() +  "/" +  build.getUrl() + viewUrl, pcModel.getserverAndPort() + "/" + build.getUrl() + downloadUrl);
     }
     
     private String getArtifactsUrlPattern(Run<?, ?> build) {

--- a/src/main/java/com/hpe/application/automation/tools/run/PcBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/PcBuilder.java
@@ -107,6 +107,7 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
     
     @DataBoundConstructor
     public PcBuilder(
+            String serverandport,
             String pcServerName,
             String almUserName,
             String almPassword,
@@ -133,6 +134,7 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
 
         pcModel =
                 new PcModel(
+                        serverandport.trim(),
                         pcServerName.trim(),
                         almUserName.trim(),
                         almPassword,
@@ -587,8 +589,8 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
         String viewUrl = String.format(urlPattern + "/%s", pcReportFileName);
         String downloadUrl = String.format(urlPattern + "/%s", "*zip*/pcRun");
         logger.println(HyperlinkNote.encodeTo(viewUrl, "View analysis report of run " + runId));
-        return String.format("Load Test Run ID: %s\n\nView analysis report:\n%s\n\nDownload Report:\n%s", runId,viewUrl, downloadUrl);
 
+        return String.format("Load Test Run ID: %s\n\nView analysis report:\n%s\n\nDownload Report:\n%s", runId, pcModel.getserverandport() +  "/" +  build.getUrl() + viewUrl, pcModel.getserverandport() + "/" + build.getUrl() + downloadUrl);
     }
     
     private String getArtifactsUrlPattern(Run<?, ?> build) {

--- a/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
@@ -422,7 +422,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 		String firstTestContent = mergedProperties.getProperty(firstTestKey, "");
 		if (RunFromFileSystemModel.isMtbxContent(firstTestContent)) {
 			try {
-				String mtbxFilePath = createMtbxFileInWs(workspace, firstTestContent);
+				String mtbxFilePath = createMtbxFileInWs(workspace, firstTestContent, time);
 				mergedProperties.setProperty(firstTestKey, mtbxFilePath);
 			} catch (IOException | InterruptedException e) {
 				build.setResult(Result.FAILURE);
@@ -504,12 +504,8 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 		}
 	}
 
-	private static String createMtbxFileInWs(FilePath workspace, String mtbxContent) throws IOException, InterruptedException {
-		Date now = new Date();
-		Format formatter = new SimpleDateFormat("ddMMyyyyHHmmssSSS");
-		String time = formatter.format(now);
-
-		String fileName = "test_suite_" + time + ".mtbx";
+	private static String createMtbxFileInWs(FilePath workspace, String mtbxContent, String timeString) throws IOException, InterruptedException {
+		String fileName = "test_suite_" + timeString + ".mtbx";
 
 		FilePath remoteFile = workspace.child(fileName);
 

--- a/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/config.jelly
@@ -44,7 +44,7 @@
             var href = window.location.href;
             var splitter = href.split("/job");
             var baseurl = splitter[0];
-            var p = document.getElementById('serverandport');
+            var p = document.getElementById('serverAndPort');
             if(p){
                 p.value = baseurl;
             }
@@ -127,8 +127,8 @@
 	<f:entry title="Project" field="almProject">
 		<f:textbox name="pc.almProject" value="${instance.pcModel.almProject}" />
 	</f:entry>
-		<f:invisibleEntry title="" field="serverandport">
-    		<f:textbox id="serverandport" name="pc.serverandport" value="" onchange="assignhostPath()" />
+		<f:invisibleEntry title="" field="serverAndPort">
+    		<f:textbox id="serverAndPort" name="pc.serverAndPort" value="" onchange="assignhostPath()" />
     	</f:invisibleEntry>
 
 

--- a/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/config.jelly
@@ -37,6 +37,23 @@
 	</style>
 	
 		<script>
+
+
+    function assignhostPath(){
+        setTimeout(function(){
+            var href = window.location.href;
+            var splitter = href.split("/job");
+            var baseurl = splitter[0];
+            var p = document.getElementById('serverandport');
+            if(p){
+                p.value = baseurl;
+            }
+        },50)
+
+    }
+
+
+
 		function isAddRunToTrendReportEnabled(sender) {
 			var x = sender.selectedIndex;
 			var y = sender.options;
@@ -110,6 +127,16 @@
 	<f:entry title="Project" field="almProject">
 		<f:textbox name="pc.almProject" value="${instance.pcModel.almProject}" />
 	</f:entry>
+		<f:invisibleEntry title="" field="serverandport">
+    		<f:textbox id="serverandport" name="pc.serverandport" value="" onchange="assignhostPath()" />
+    	</f:invisibleEntry>
+
+
+        <script>assignhostPath();</script>
+
+
+
+
 	<f:entry title="Test ID" field="testId">
 		<f:textbox name="pc.testId" value="${instance.pcModel.testId}" />
 	</f:entry>

--- a/src/main/webapp/help/impersonatedUser.html
+++ b/src/main/webapp/help/impersonatedUser.html
@@ -5,7 +5,7 @@ The Jenkins user's account is used to run jobs that ALM Octane runs.<br><br>
         Make sure the user exists in Jenkins.
     </li>
     <li>
-        We strongly recommend specifying a Jenkins user for ALM Octane. Set this user's permissions to the minimum required for this integration: <b>Job Build</b> permissions.
+        We strongly recommend specifying a Jenkins user for ALM Octane. Set this user's permissions to the minimum required for this integration: <b>Job Build and Read</b> permissions.
     </li>
     <li>
         If you do not specify a Jenkins user, ALM Octane uses the Anonymous user, and is limited to <b>Anonymous's</b> user permissions.

--- a/src/test/java/com/hpe/application/automation/tools/pc/MockPcModel.java
+++ b/src/test/java/com/hpe/application/automation/tools/pc/MockPcModel.java
@@ -8,10 +8,10 @@ import com.hpe.application.automation.tools.model.SecretContainerTest;
 public class MockPcModel extends PcModel {
 
 
-    public MockPcModel(String pcServerName, String almUserName, String almPassword, String almDomain,
+    public MockPcModel(String serverandport, String pcServerName, String almUserName, String almPassword, String almDomain,
                        String almProject, String testId, String autoTestInstanceID, String testInstanceId, String timeslotDurationHours,
                        String timeslotDurationMinutes, PostRunAction postRunAction, boolean vudsMode, String description, boolean webProtocol) {
-        super(pcServerName, almUserName, almPassword, almDomain, almProject, testId, autoTestInstanceID, testInstanceId, timeslotDurationHours,
+        super(serverandport, pcServerName, almUserName, almPassword, almDomain, almProject, testId, autoTestInstanceID, testInstanceId, timeslotDurationHours,
             timeslotDurationMinutes, postRunAction, vudsMode, description, "NO_TREND", null,false,null
         );
     }

--- a/src/test/java/com/hpe/application/automation/tools/pc/MockPcModel.java
+++ b/src/test/java/com/hpe/application/automation/tools/pc/MockPcModel.java
@@ -8,10 +8,10 @@ import com.hpe.application.automation.tools.model.SecretContainerTest;
 public class MockPcModel extends PcModel {
 
 
-    public MockPcModel(String serverandport, String pcServerName, String almUserName, String almPassword, String almDomain,
+    public MockPcModel(String serverAndPort, String pcServerName, String almUserName, String almPassword, String almDomain,
                        String almProject, String testId, String autoTestInstanceID, String testInstanceId, String timeslotDurationHours,
                        String timeslotDurationMinutes, PostRunAction postRunAction, boolean vudsMode, String description, boolean webProtocol) {
-        super(serverandport, pcServerName, almUserName, almPassword, almDomain, almProject, testId, autoTestInstanceID, testInstanceId, timeslotDurationHours,
+        super(serverAndPort, pcServerName, almUserName, almPassword, almDomain, almProject, testId, autoTestInstanceID, testInstanceId, timeslotDurationHours,
             timeslotDurationMinutes, postRunAction, vudsMode, description, "NO_TREND", null,false,null
         );
     }

--- a/src/test/java/com/hpe/application/automation/tools/pc/PcTestBase.java
+++ b/src/test/java/com/hpe/application/automation/tools/pc/PcTestBase.java
@@ -22,7 +22,8 @@ import java.io.PrintStream;
 
 public interface PcTestBase {
 
-    public static final String        PC_SERVER_NAME                  = "pcServer.hp.com";
+	public static final String        SERVER_AND_PORT                 = "jenkins.server:8082";
+	public static final String        PC_SERVER_NAME                  = "pcServer.hp.com";
     public static final String        ALM_USER_NAME                   = "sa";
     public static final String        ALM_PASSWORD                    = "pwd";
     public static final String        ALM_DOMAIN                      = "ALMDOM";
@@ -44,7 +45,7 @@ public interface PcTestBase {
 	public static final String 	  TESTINSTANCEID				= "MANUAL";
 	public static final PrintStream LOGGER					  	  = null;
 
-    public static final MockPcModel   pcModel                         = new MockPcModel(PC_SERVER_NAME, ALM_USER_NAME,
+    public static final MockPcModel   pcModel                         = new MockPcModel(SERVER_AND_PORT,PC_SERVER_NAME, ALM_USER_NAME,
                                                                           ALM_PASSWORD, ALM_DOMAIN, ALM_PROJECT,
                                                                           TEST_ID,TESTINSTANCEID, TEST_INSTANCE_ID,
                                                                           TIMESLOT_DURATION_HOURS,


### PR DESCRIPTION
New Features:
* expose plugin version [JENKINS-46716](https://issues.jenkins-ci.org/browse/JENKINS-46716)
* Expose Jenkins user + Octane user/APIKey for DevOps Admin [JENKINS-46870](https://issues.jenkins-ci.org/browse/JENKINS-46870)
*	Define Shared checkout repo folder for the UFT execution jobs [JENKINS-46846](https://issues.jenkins-ci.org/browse/JENKINS-46846)

Fixes:
* making mtbx file to have the same time stamp suffix as prop file [JENKINS-46717](https://issues.jenkins-ci.org/browse/JENKINS-46717)
*	defect FIX #432027  - [LA] Jenkins doesn't send logs of foldered jobs [JENKINS-46711](https://issues.jenkins-ci.org/browse/JENKINS-46711)
* Results links are not showing, it only appears a plain text file location instead [JENKINS-45863](https://issues.jenkins-ci.org/browse/JENKINS-45863)
