### PR TITLE
second fix defect: Snippet Generator fails to create snippet

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/run/PcBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/PcBuilder.java
@@ -691,6 +691,10 @@ public class PcBuilder extends Builder implements SimpleBuildStep{
 
     }
 
+    public String getServerAndPort()
+    {
+        return getPcModel().getserverAndPort();
+    }
     public String getPcServerName()
     {
         return getPcModel().getPcServerName();


### PR DESCRIPTION
second fix defect: Snippet Generator fails to create snippet
fixing defect: https://issues.jenkins-ci.org/browse/JENKINS-46423
For the second time after another fix (45863) caused the same issue