### PR TITLE
fix errata (#48)

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/octane/executor/CheckOutSubDirEnvContributor.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/executor/CheckOutSubDirEnvContributor.java
@@ -43,7 +43,7 @@ public class CheckOutSubDirEnvContributor extends EnvironmentContributor {
     }
 
     public static String getSharedCheckOutDirectory(Job j) {
-        if (j instanceof FreeStyleProject && UftJobRecognizer.isExecutorJob((FreeStyleProject) j) && !ConfigurationService.getServerConfiguration().isValid()) {
+        if (j instanceof FreeStyleProject && UftJobRecognizer.isExecutorJob((FreeStyleProject) j) && ConfigurationService.getServerConfiguration().isValid()) {
             return CheckOutSubDirEnvService.getSharedCheckOutDirectory(j);
         }
 


### PR DESCRIPTION
We should step into getSharedCheckOutDirectory when ConfigurationService.getServerConfiguration().isValid().

Previous validation was misstyped : !ConfigurationService.getServerConfiguration().isValid() 

[JENKINS-47117](https://issues.jenkins-ci.org/browse/JENKINS-47117)