### PR TITLE
Bug JENKINS-50732: ensure application to be uploaded even if instrumentation fails during app upload

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/mc/Constants.java
+++ b/src/main/java/com/hpe/application/automation/tools/mc/Constants.java
@@ -43,7 +43,7 @@ package com.hpe.application.automation.tools.mc;
 public class Constants {
     public final static String BOUNDARYSTR = "randomstring";
     public final static String DATA = "data";
-    public final static String APP_UPLOAD = "/rest/apps/upload";
+    public final static String APP_UPLOAD = "/rest/apps/upload?enforceUpload=true";  // make sure unpacked app is uploaded in case of failure during instrumentation
     public final static String CONTENT_TYPE_DOWNLOAD_VALUE = "multipart/form-data; boundary=----";
     public final static String FILENAME = "filename";
     public static final String LOGIN_SECRET = "x-hp4msecret";


### PR DESCRIPTION
Ensure non-packaged application to be uploaded even if instrumentation fails during app instrumentation.

Related Jira ticket is: JENKINS-50732 at link https://issues.jenkins-ci.org/browse/JENKINS-50732

Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [x] Proper pull request title - concise and clear for others.
- [x] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [x] Proper Jira ticket - Number, Link in pull request description.
- [x] The PR can is merged on your machine without any conflicts.
- [x] The PR can is built on your machine without any (new) warnings.
- [x] The PR passed sanity tests by you / QA / DevTest / Good Samaritain.
- [x] Add unit tests with new features.
- [ ] If you added any dependency to the POM - Please update YafimK
