### PR TITLE
Display LR Controller during jenkins job

### DIFF
--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -312,6 +312,15 @@ namespace HpToolsLauncher
                                      sets);
                     break;
                 case TestStorageType.FileSystem:
+                    //Get displayController var
+                    bool displayController = false;
+                    if (_ciParams.ContainsKey("displayController")) {
+                        if (_ciParams["displayController"] == "1")
+                        {
+                            displayController = true;
+                        }
+                    }
+
 
                     //get the tests
                     IEnumerable<string> tests = GetParamsWithPrefix("Test");
@@ -511,11 +520,11 @@ namespace HpToolsLauncher
                     {
                         string uftRunMode = "Fast";
                         uftRunMode = _ciParams["fsUftRunMode"];
-                        runner = new FileSystemTestsRunner(validTests, timeout, uftRunMode, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo);
+                        runner = new FileSystemTestsRunner(validTests, timeout, uftRunMode, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, displayController);
                     }
                     else
                     {
-                        runner = new FileSystemTestsRunner(validTests, timeout, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo);
+                        runner = new FileSystemTestsRunner(validTests, timeout, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, displayController);
                     }
 
                     break;

--- a/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
+++ b/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
@@ -64,7 +64,7 @@ namespace HpToolsLauncher
                                     string mobileInfo,
                                     bool displayController,
                                     bool useUFTLicense = false)
-            :this(sources, timeout, ControllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, useUFTLicense, displayController)
+            :this(sources, timeout, ControllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, displayController, useUFTLicense)
         {
             _uftRunMode = uftRunMode;
         }
@@ -84,7 +84,7 @@ namespace HpToolsLauncher
                                     Dictionary<string, string> jenkinsEnvVariables,
                                     McConnectionInfo mcConnection,
                                     string mobileInfo,
-                                     bool displayController,
+                                    bool displayController,
                                     bool useUFTLicense = false)
         {
             _jenkinsEnvVariables = jenkinsEnvVariables;

--- a/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
+++ b/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
@@ -22,6 +22,7 @@ namespace HpToolsLauncher
         private static string _uftViewerPath;
         private int _errors, _fail;
         private bool _useUFTLicense;
+        private bool _displayController;
         private TimeSpan _timeout = TimeSpan.MaxValue;
         private readonly string _uftRunMode;
         private Stopwatch _stopwatch = null;
@@ -61,8 +62,9 @@ namespace HpToolsLauncher
                                     Dictionary<string, string> jenkinsEnvVariables,
                                     McConnectionInfo mcConnection,
                                     string mobileInfo,
+                                    bool displayController,
                                     bool useUFTLicense = false)
-            :this(sources, timeout, ControllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, useUFTLicense)
+            :this(sources, timeout, ControllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, useUFTLicense, displayController)
         {
             _uftRunMode = uftRunMode;
         }
@@ -82,6 +84,7 @@ namespace HpToolsLauncher
                                     Dictionary<string, string> jenkinsEnvVariables,
                                     McConnectionInfo mcConnection,
                                     string mobileInfo,
+                                     bool displayController,
                                     bool useUFTLicense = false)
         {
             _jenkinsEnvVariables = jenkinsEnvVariables;
@@ -99,9 +102,9 @@ namespace HpToolsLauncher
             _pollingInterval = ControllerPollingInterval;
             _perScenarioTimeOutMinutes = perScenarioTimeOutMinutes;
             _ignoreErrorStrings = ignoreErrorStrings;
-
-
+            
             _useUFTLicense = useUFTLicense;
+            _displayController = displayController;
             _tests = new List<TestInfo>();
 
             _mcConnection = mcConnection;
@@ -306,11 +309,10 @@ namespace HpToolsLauncher
                     break;
                 case TestType.LoadRunner:
                     AppDomain.CurrentDomain.AssemblyResolve += Helper.HPToolsAssemblyResolver;
-                    runner = new PerformanceTestRunner(this, _timeout, _pollingInterval, _perScenarioTimeOutMinutes, _ignoreErrorStrings);
+                    runner = new PerformanceTestRunner(this, _timeout, _pollingInterval, _perScenarioTimeOutMinutes, _ignoreErrorStrings, _displayController);
                     break;
             }
-
-
+            
             if (runner != null)
             {
                 if (!_colRunnersForCleanup.ContainsKey(type))

--- a/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
+++ b/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
@@ -46,6 +46,7 @@ namespace HpToolsLauncher.TestRunners
         private int _pollingInterval;
         private TimeSpan _perScenarioTimeOutMinutes;
         private RunCancelledDelegate _runCancelled;
+        private bool _displayController;
 
         private bool _scenarioEnded;
         private bool _scenarioEndedEvent;
@@ -82,17 +83,15 @@ namespace HpToolsLauncher.TestRunners
 
         Dictionary<string, ControllerError> _errors;
         int _errorsCount;
-
-
-
-
-        public PerformanceTestRunner(IAssetRunner runner, TimeSpan timeout, int pollingInterval, TimeSpan perScenarioTimeOut, List<string> ignoreErrorStrings)
+        
+        public PerformanceTestRunner(IAssetRunner runner, TimeSpan timeout, int pollingInterval, TimeSpan perScenarioTimeOut, List<string> ignoreErrorStrings, bool displayController)
         {
             this._runner = runner;
             this._timeout = timeout;
             this._pollingInterval = pollingInterval;
             this._perScenarioTimeOutMinutes = perScenarioTimeOut;
             this._ignoreErrorStrings = ignoreErrorStrings;
+            this._displayController = displayController;
             this._scenarioEnded = false;
             _engine = null;
             this._errors = null;
@@ -152,6 +151,7 @@ namespace HpToolsLauncher.TestRunners
             //init result params
             runDesc.ErrorDesc = errorReason;
             runDesc.TestPath = scenarioPath;
+            ConsoleWriter.WriteLine(runDesc.TestPath);
             runDesc.TestState = TestState.Unknown;
 
             if (!Helper.isLoadRunnerInstalled())
@@ -295,7 +295,7 @@ namespace HpToolsLauncher.TestRunners
         private bool runScenario(string scenario, ref string errorReason, RunCancelledDelegate runCancelled)
         {
             cleanENV();
-
+            
             ConsoleWriter.WriteLine(string.Format(Resources.LrInitScenario, scenario));
 
             //start controller
@@ -319,10 +319,15 @@ namespace HpToolsLauncher.TestRunners
                 _scenarioEndedEvent = false;
             }
 
-            _engine.ShowMainWindow(0);
-#if DEBUG
-            _engine.ShowMainWindow(1);
-#endif
+            
+            if (_displayController == true)
+            {
+                _engine.ShowMainWindow(1);
+            } else
+            {
+                _engine.ShowMainWindow(0);
+            }
+
             //pointer to the scenario object:
             LrScenario currentScenario = _engine.Scenario;
 

--- a/src/main/java/com/hpe/application/automation/tools/model/RunFromFileSystemModel.java
+++ b/src/main/java/com/hpe/application/automation/tools/model/RunFromFileSystemModel.java
@@ -66,6 +66,7 @@ public class RunFromFileSystemModel {
     private String controllerPollingInterval;
     private String perScenarioTimeOut;
     private String ignoreErrorStrings;
+    private String displayController;
     private String mcServerName;
     private String fsUserName;
     private Secret fsPassword;
@@ -91,6 +92,7 @@ public class RunFromFileSystemModel {
      * @param controllerPollingInterval the controller polling interval in minutes
      * @param perScenarioTimeOut        the per scenario time out in minutes
      * @param ignoreErrorStrings        the ignore error strings
+     * @param displayController         the display controller
      * @param mcServerName              the mc server name
      * @param fsUserName                the fs user name
      * @param fsPassword                the fs password
@@ -109,7 +111,7 @@ public class RunFromFileSystemModel {
      */
     @SuppressWarnings("squid:S00107")
     public RunFromFileSystemModel(String fsTests, String fsTimeout, String fsUftRunMode, String controllerPollingInterval,String perScenarioTimeOut,
-                                  String ignoreErrorStrings, String mcServerName, String fsUserName, String fsPassword,
+                                  String ignoreErrorStrings, String displayController, String mcServerName, String fsUserName, String fsPassword,
                                   String fsDeviceId, String fsTargetLab, String fsManufacturerAndModel, String fsOs,
                                   String fsAutActions, String fsLaunchAppName, String fsDevicesMetrics, String fsInstrumented,
                                   String fsExtraApps, String fsJobId, ProxySettings proxySettings, boolean useSSL) {
@@ -122,6 +124,7 @@ public class RunFromFileSystemModel {
         this.perScenarioTimeOut = perScenarioTimeOut;
         this.controllerPollingInterval = controllerPollingInterval;
         this.ignoreErrorStrings = ignoreErrorStrings;
+        this.displayController = displayController;
 
         this.mcServerName = mcServerName;
         this.fsUserName = fsUserName;
@@ -160,6 +163,7 @@ public class RunFromFileSystemModel {
         this.controllerPollingInterval = "30";
         this.perScenarioTimeOut = "10";
         this.ignoreErrorStrings = "";
+        this.displayController = "false";
     }
 
 
@@ -540,6 +544,24 @@ public class RunFromFileSystemModel {
     }
 
     /**
+     * Gets display controller.
+     *
+     * @return the displayController
+     */
+    public String getDisplayController() {
+        return displayController;
+    }
+
+    /**
+     * Sets display controller.
+     *
+     * @param displayController the displayController to set
+     */
+    public void setDisplayController(String displayController) {
+        this.displayController = displayController;
+    }
+
+    /**
      * Gets ignore error strings.
      *
      * @return the ignoreErrorStrings
@@ -654,12 +676,18 @@ public class RunFromFileSystemModel {
             props.put("fsUftRunMode", "" + fsUftRunMode);
         }
 
-
         if (StringUtils.isEmpty(controllerPollingInterval)){
             props.put("controllerPollingInterval", "30");
         }
         else{
             props.put("controllerPollingInterval", "" + controllerPollingInterval);
+        }
+
+       if (StringUtils.isEmpty(displayController) || displayController.equals("false")){
+            props.put("displayController", "0");
+        }
+        else{
+            props.put("displayController", "1");
         }
 
         if (StringUtils.isEmpty(perScenarioTimeOut)){

--- a/src/main/java/com/hpe/application/automation/tools/pipelineSteps/LoadRunnerTestStep.java
+++ b/src/main/java/com/hpe/application/automation/tools/pipelineSteps/LoadRunnerTestStep.java
@@ -166,6 +166,25 @@ public class LoadRunnerTestStep extends AbstractStepImpl {
     }
 
     /**
+     * Gets display controller.
+     *
+     * @return the display controller
+     */
+    public String getDisplayController() {
+        return runFromFileBuilder.getRunFromFileModel().getDisplayController();
+    }
+
+    /**
+     * Sets display controller.
+     *
+     * @param displayController the display controller
+     */
+    @DataBoundSetter
+    public void setDisplayController(String displayController) {
+        runFromFileBuilder.setDisplayController(displayController);
+    }
+
+    /**
      * Gets run from file builder.
      *
      * @return the run from file builder

--- a/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
@@ -123,6 +123,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 	 * @param controllerPollingInterval the controller polling interval
 	 * @param perScenarioTimeOut        the per scenario time out
 	 * @param ignoreErrorStrings        the ignore error strings
+	 * @param displayController         the display controller
 	 * @param mcServerName              the mc server name
 	 * @param fsUserName                the fs user name
 	 * @param fsPassword                the fs password
@@ -142,12 +143,12 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 	@SuppressWarnings("squid:S00107")
 	@Deprecated
 	public RunFromFileBuilder(String fsTests, String fsTimeout, String fsUftRunMode, String controllerPollingInterval,
-                              String perScenarioTimeOut, String ignoreErrorStrings, String mcServerName, String fsUserName, String fsPassword, String fsDeviceId, String fsTargetLab,
+                              String perScenarioTimeOut, String ignoreErrorStrings, String displayController, String mcServerName, String fsUserName, String fsPassword, String fsDeviceId, String fsTargetLab,
                               String fsManufacturerAndModel, String fsOs, String fsAutActions, String fsLaunchAppName, String fsDevicesMetrics, String fsInstrumented, String fsExtraApps, String fsJobId,
                               ProxySettings proxySettings, boolean useSSL) {
 
 		runFromFileModel = new RunFromFileSystemModel(fsTests, fsTimeout, fsUftRunMode, controllerPollingInterval,
-				perScenarioTimeOut, ignoreErrorStrings, mcServerName, fsUserName, fsPassword, fsDeviceId, fsTargetLab, fsManufacturerAndModel, fsOs, fsAutActions, fsLaunchAppName,
+				perScenarioTimeOut, ignoreErrorStrings, displayController, mcServerName, fsUserName, fsPassword, fsDeviceId, fsTargetLab, fsManufacturerAndModel, fsOs, fsAutActions, fsLaunchAppName,
 				fsDevicesMetrics, fsInstrumented, fsExtraApps, fsJobId, proxySettings, useSSL);
 	}
 
@@ -188,6 +189,16 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 	@DataBoundSetter
 	public void setIgnoreErrorStrings(String ignoreErrorStrings) {
 		runFromFileModel.setIgnoreErrorStrings(ignoreErrorStrings);
+	}
+
+	/**
+	 * Sets display controller.
+	 *
+	 * @param displayController the display controller
+	 */
+	@DataBoundSetter
+	public void setDisplayController(String displayController) {
+		runFromFileModel.setDisplayController(displayController);
 	}
 
 	/**

--- a/src/main/resources/com/hpe/application/automation/tools/pipelineSteps/LoadRunnerTestStep/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/pipelineSteps/LoadRunnerTestStep/config.jelly
@@ -63,6 +63,9 @@
             <f:entry title="Errors to Ignore" field="ignoreErrorStrings">
                 <f:textarea name="runPipeline.ignoreErrorStrings" value="${instance.ignoreErrorStrings}" default=""/>
             </f:entry>
+            <f:entry title="Display Controller" field="displayController">
+                <f:checkbox name="runPipeline.displayController" value="${instance.displayController}"/>
+            </f:entry>
         </f:advanced>
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/hpe/application/automation/tools/pipelineSteps/LoadRunnerTestStep/help-displayController.html
+++ b/src/main/resources/com/hpe/application/automation/tools/pipelineSteps/LoadRunnerTestStep/help-displayController.html
@@ -1,0 +1,36 @@
+<!--
+  ~ © Copyright 2013 EntIT Software LLC
+  ~  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+  ~  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+  ~  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+  ~  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+  ~  marks are the property of their respective owners.
+  ~ __________________________________________________________________
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2018 Micro Focus Company, L.P.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  ~ ___________________________________________________________________
+  ~
+  -->
+
+<div>
+Display the controller while the scenario is running.
+</div>


### PR DESCRIPTION
Added a checkbox in the pipeline syntax (LoadRunner advanced Settings) for displaying the LR Controller during the jenkins job if checked.
Jira ticket: https://issues.jenkins-ci.org/browse/JENKINS-28075
