### PR TITLE
Issue: 40213 (Console log recognizes folders which start with letter "n" as new line) and Issue: 50329 (Timeout and Scenario Execution Timeout can't accept parameter values)

### DIFF
--- a/HpToolsLauncher/ConsoleWriter.cs
+++ b/HpToolsLauncher/ConsoleWriter.cs
@@ -76,7 +76,6 @@ namespace HpToolsLauncher
 
         public static void WriteLine(string message)
         {
-            message = message.Replace("\\n", "\n");
             message = FilterXmlProblematicChars(message);
             //File.AppendAllText("c:\\stam11.stam", message);
             Console.Out.WriteLine(message);

--- a/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
@@ -736,7 +736,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 				sanitizedValue = sanitizedValue.substring(1);
 			}
 
-			if (!sanitizedValue.matches("^\\$\\{[\\w-. ]*}$|^\\$[\\w-.]*$") && !sanitizedValue.matches("[0-9]*$")) {
+			if (!isParameterizedValue(sanitizedValue) && !StringUtils.isNumeric(sanitizedValue)) {
 				return FormValidation.error("Timeout must be a parameter or a number, e.g.: 23, $Timeout or ${Timeout}.");
 			}
 
@@ -795,11 +795,21 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 				return FormValidation.ok();
 			}
 
-			if (!value.matches("^\\$\\{[\\w-. ]*}$|^\\$[\\w-.]*$") && !value.matches("[0-9]*$")) {
+			if (!isParameterizedValue(value) && !StringUtils.isNumeric(value)) {
 				return FormValidation.error("Per Scenario Timeout must be a parameter or a number, e.g.: 23, $ScenarioDuration or ${ScenarioDuration}.");
 			}
 
-            return FormValidation.ok();
+            		return FormValidation.ok();
+		}
+		/**
+		 * Check if the value is parameterized.
+		 *
+		 * @param value the value
+		 * @return boolean
+		 */
+		public boolean isParameterizedValue(String value) {
+			//Parameter (with or without brackets)
+			return value.matches("^\\$\\{[\\w-. ]*}$|^\\$[\\w-.]*$");
 		}
 	}
 }

--- a/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
@@ -731,12 +731,12 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 				return FormValidation.ok();
 			}
 
-			String val1 = value.trim();
-			if (val1.length() > 0 && val1.charAt(0) == '-') {
-				val1 = val1.substring(1);
+			String sanitizedValue = value.trim();
+			if (sanitizedValue.length() > 0 && sanitizedValue.charAt(0) == '-') {
+				sanitizedValue = sanitizedValue.substring(1);
 			}
 
-			if (!val1.matches("^\\$\\{[\\w-. ]*}$|^\\$[\\w-.]*$") && !val1.matches("[0-9]*$")) {
+			if (!sanitizedValue.matches("^\\$\\{[\\w-. ]*}$|^\\$[\\w-.]*$") && !sanitizedValue.matches("[0-9]*$")) {
 				return FormValidation.error("Timeout must be a parameter or a number, e.g.: 23, $Timeout or ${Timeout}.");
 			}
 

--- a/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
@@ -733,7 +733,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 
 			String val1 = value.trim();
 			if (val1.length() > 0 && val1.charAt(0) == '-') {
-				value = value.substring(1);
+				val1 = val1.substring(1);
 			}
 
 			if (!val1.matches("^\\$\\{[\\w-. ]*}$|^\\$[\\w-.]*$") && !val1.matches("[0-9]*$")) {


### PR DESCRIPTION
Scenario paths that contain folders whose names start with letter "n" are displayed properly in console.

Jira ticket: https://issues.jenkins-ci.org/browse/JENKINS-40213