### PR TITLE
JENKINS-52366

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+# TimeslotDuration class from com.microfocus.adm.performancecenter.plugins.common.pcEntities package is safe to be used.
+com.microfocus.adm.performancecenter.plugins.common.pcEntities.TimeslotDuration

--- a/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/help-proxyOutURL.html
+++ b/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/help-proxyOutURL.html
@@ -34,5 +34,5 @@
 <div>
     Add your local proxy as following: <b>http(s)://&#60;host&#62;:&#60;port&#62;</b> or
     Leave empty if not using a local proxy.<br>
-    PAC (proxy auto-config) or Automatic configuration script are not supported.
+    PAC (proxy auto-config) or <br>Automatic configuration script are not supported.
 </div>


### PR DESCRIPTION
### JENKINS-52366: Error saving jobs utilizing the HPE Application Automation Tools plugin - "TimeslotDuration" class error
Following Jenkins recommendation regarding whitelisting third-party bundled: "If the class(es) are defined in a third-party library bundled in your plugin, create a resource file META-INF/hudson.remoting.ClassFilter listing them."
https://issues.jenkins-ci.org/browse/JENKINS-52366

### BTW: JENKINS-47722 "Local Proxy" textbox tooltip: the text slides outside of the visible area
adding html carriage return in the middle of the sentence. 
https://issues.jenkins-ci.org/browse/JENKINS-47722
