### PR TITLE
[JENKINS-52617] Add support for converting Global Configurations

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/run/JobConfigRebrander.java
+++ b/src/main/java/com/microfocus/application/automation/tools/run/JobConfigRebrander.java
@@ -27,6 +27,7 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.XmlFile;
 import hudson.model.AbstractProject;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
@@ -49,7 +50,7 @@ import java.nio.file.Paths;
 public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
     private static final String HPE = ".hpe.";
     private static final String HP = ".hp.";
-
+    private Run<?, ?> build;
     @DataBoundConstructor
     public JobConfigRebrander() {
         // A class which extends Builder should supply an empty constructor.
@@ -121,6 +122,7 @@ public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
             }
         } catch (SecurityException | NullPointerException e) {
             listener.error("Failed to convert Global Settings configurations to microfocus: %s", e.getMessage());
+            build.setResult(Result.FAILURE);
         }
     }
 
@@ -147,6 +149,7 @@ public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
             } catch (IOException | SecurityException e) {
                 listener.error("Failed to delete %s when doing Global Settings configurations convert: %s",
                         newFileName, e.getMessage());
+                build.setResult(Result.UNSTABLE);
             }
         }
     }
@@ -165,6 +168,7 @@ public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
             FileUtils.writeStringToFile(confXmlFile.getFile(), newConfiguration);
         } catch (IOException e) {
             listener.error("Failed to convert job configuration format from %s to microfocus: %s", oldName, e.getMessage());
+            build.setResult(Result.FAILURE);
         }
     }
 

--- a/src/main/java/com/microfocus/application/automation/tools/run/JobConfigRebrander.java
+++ b/src/main/java/com/microfocus/application/automation/tools/run/JobConfigRebrander.java
@@ -37,18 +37,22 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
- * Created in order to fix previous builds that we're build with HP convention plugin and move them to HPE
+ * Created in order to fix previous builds that we're build with HP/HPE convention plugin and move them to Micro Focus
  */
 public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
+    private static final String HPE = ".hpe.";
+    private static final String HP = ".hp.";
 
     @DataBoundConstructor
     public JobConfigRebrander() {
+        // A class which extends Builder should supply an empty constructor.
     }
 
     /**
@@ -62,39 +66,105 @@ public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
      */
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
-                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
+                        @Nonnull TaskListener listener) throws InterruptedException, IOException{
         File root = Jenkins.getInstance().getRootDir();
+        convertXmlFilesAtRootDir(listener, root);
         File projectsDir = new File(root,"jobs");
         File[] subdirs = projectsDir.listFiles();
-        for (final File subdir : subdirs) {
-            XmlFile xmlFile = new XmlFile(new File(subdir,"config.xml"));
-            if (xmlFile.exists()) {
-                convertOldNameToNewName(listener, xmlFile, ".hp.");
-                convertOldNameToNewName(listener, xmlFile, ".hpe.");
-            }
 
+        for (final File subdir : subdirs) {
+            convertSpecifiedXmlFile(listener, subdir, "config.xml");
             final File buildsFolder = new File(subdir, "builds");
             File[] builds = buildsFolder.listFiles();
+
             for(final File buildDir : builds){
-                XmlFile buildXmlFile = new XmlFile(new File(buildDir,"build.xml"));
-                if (buildXmlFile.exists()) {
-                    convertOldNameToNewName(listener, buildXmlFile, ".hp.");
-                    convertOldNameToNewName(listener, buildXmlFile, ".hpe.");
-                }
+                convertSpecifiedXmlFile(listener, buildDir, "build.xml");
             }
-
         }
-
     }
 
+    /**
+     * Creates XML file of the file we want to convert.
+     * And calls {@link JobConfigRebrander#convertOldNameToNewName(TaskListener, XmlFile, String)}
+     * to convert from all the old package names.
+     * @param listener      A place to send log output
+     * @param dir           The directory which we create the file
+     * @param xmlFileName   The XML file name
+     */
+    private void convertSpecifiedXmlFile(@Nonnull TaskListener listener, File dir, String xmlFileName) {
+        XmlFile xmlFile = new XmlFile(new File(dir, xmlFileName));
+        if (xmlFile.exists()) {
+            convertOldNameToNewName(listener, xmlFile, HP);
+            convertOldNameToNewName(listener, xmlFile, HPE);
+        }
+    }
+
+    /**
+     * Converts xml files which is located in the root directory
+     * That is responsible for the configuration files located at the "Manage Jenkins -> Configure System".
+     * @param listener  a place to send log output
+     * @param root      the root directory
+     */
+    private void convertXmlFilesAtRootDir(@Nonnull TaskListener listener, File root) {
+        try {
+            File[] files = root.listFiles(pathname -> {
+                String name = pathname.getName().toLowerCase();
+                return name.startsWith("com.hpe") && name.endsWith(".xml") && pathname.isFile();
+            });
+
+            for (File file: files) {
+                String newFileName = file.toString().replace(HPE, ".microfocus.");
+                File replacedFile  = new File(newFileName);
+
+                removeXmlFileIfExists(listener, newFileName, replacedFile);
+                convertXmlFileIfNotExists(listener, file, replacedFile);
+            }
+        } catch (SecurityException | NullPointerException e) {
+            listener.error("Failed to convert Global Settings configurations to microfocus: %s", e.getMessage());
+        }
+    }
+
+    private void convertXmlFileIfNotExists(@Nonnull TaskListener listener, File file, File replacedFile) {
+        if (!replacedFile.exists() && file.renameTo(replacedFile)) {
+            XmlFile xmlFile = new XmlFile(replacedFile);
+            convertOldNameToNewName(listener, xmlFile, HP);
+            convertOldNameToNewName(listener, xmlFile, HPE);
+        }
+    }
+
+    /**
+     * There are files which can be auto-generated as empty after the package name change.
+     * We need to remove them in order to let the
+     * {@link JobConfigRebrander#convertXmlFileIfNotExists(TaskListener, File, File)} do the convert.
+     * @param listener      a place to send log output
+     * @param newFileName   the new file absolute path
+     * @param replacedFile  the new file name which we need to remove
+     */
+    private void removeXmlFileIfExists(@Nonnull TaskListener listener, String newFileName, File replacedFile) {
+        if (replacedFile.exists()) {
+            try {
+                Files.delete(Paths.get(replacedFile.getAbsolutePath()));
+            } catch (IOException | SecurityException e) {
+                listener.error("Failed to delete %s when doing Global Settings configurations convert: %s",
+                        newFileName, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Replace all occurrences of {@code oldName} of a given XML file.
+     * @param listener    A place to send log output
+     * @param confXmlFile The XML file which we convert
+     * @param oldName     The name which we convert from
+     * @see XmlFile
+     */
     private void convertOldNameToNewName(@Nonnull TaskListener listener, XmlFile confXmlFile, String oldName) {
         try {
             String configuration = FileUtils.readFileToString(confXmlFile.getFile());
             String newConfiguration = StringUtils.replace(configuration, oldName, ".microfocus.");
             FileUtils.writeStringToFile(confXmlFile.getFile(), newConfiguration);
         } catch (IOException e) {
-            listener.error(
-                    String.format("failed to convert configuration format (%s to microfocus): %s", oldName, e.getMessage()));
+            listener.error("Failed to convert job configuration format from %s to microfocus: %s", oldName, e.getMessage());
         }
     }
 
@@ -115,7 +185,5 @@ public class JobConfigRebrander  extends Builder implements SimpleBuildStep {
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }
-
     }
-
 }


### PR DESCRIPTION
It is required to convert the old package name from the additional XML files that are responsible for global configurations.

https://issues.jenkins-ci.org/browse/JENKINS-52617