### PR TITLE
ALM1260 requires an xml request body even if client type is not needed.

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
+++ b/src/main/java/com/microfocus/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
@@ -101,12 +101,7 @@ public final class AuthenticationTool {
     }
 
     private static byte[] generateClientTypeData(String clientType) {
-        if (clientType !=null && !clientType.isEmpty()) {
-            String data = String.format("<session-parameters><client-type>%s</client-type></session-parameters>", clientType);
-            return data.getBytes();
-        }
-        else {
-            return new byte[1]; // For some server requires post request has a Content-Length.
-        }
+        String data = String.format("<session-parameters><client-type>%s</client-type></session-parameters>", clientType);
+        return data.getBytes();
     }
 }


### PR DESCRIPTION
ALM1260 requires an xml request body even if client type is not needed.