### PR TITLE
Fix AutEnvironmentBuilder step name to include 'Execute'

### DIFF
--- a/src/main/resources/com/microfocus/application/automation/tools/Messages.properties
+++ b/src/main/resources/com/microfocus/application/automation/tools/Messages.properties
@@ -21,5 +21,5 @@
 CompanyName=Micro Focus
 RunFromAlmBuilderStepName=Execute {0} functional tests from {0} ALM
 SseBuilderStepName=Execute {0} tests using {0} ALM Lab Management
-AutEnvironmentBuilderStepName=AUT Environment preparation using {0} ALM Lab Management
+AutEnvironmentBuilderStepName=Execute AUT Environment preparation using {0} ALM Lab Management
 RunFromFileBuilderStepName=Execute {0} tests from file system


### PR DESCRIPTION
The AutEnvironmentBuilder step name should also contain 'Execute'

JIRA Ticket: https://issues.jenkins-ci.org/browse/JENKINS-54118
