### PR TITLE
Summary data logging

### DIFF
--- a/HpToolsLauncher/HpToolsLauncher.csproj
+++ b/HpToolsLauncher/HpToolsLauncher.csproj
@@ -116,6 +116,7 @@
     <Compile Include="TestParameterInfo.cs" />
     <Compile Include="TestRunners\ParallelTestRunner.cs" />
     <Compile Include="TestRunners\PerformanceTestRunner.cs" />
+    <Compile Include="TestRunners\SummaryDataLogger.cs" />
     <Compile Include="TestRunResults.cs" />
     <Compile Include="TestRunners\GuiTestRunner.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using HpToolsLauncher.Properties;
+using HpToolsLauncher.TestRunners;
 
 namespace HpToolsLauncher
 {
@@ -575,15 +576,16 @@ namespace HpToolsLauncher
                         }
                     }
 
+                    SummaryDataLogger summaryDataLogger = GetSummaryDataLogger();
                     if (_ciParams.ContainsKey("fsUftRunMode"))
                     {
                         string uftRunMode = "Fast";
                         uftRunMode = _ciParams["fsUftRunMode"];
-                        runner = new FileSystemTestsRunner(validTests, timeout, uftRunMode, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate);
+                        runner = new FileSystemTestsRunner(validTests, timeout, uftRunMode, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger);
                     }
                     else
                     {
-                        runner = new FileSystemTestsRunner(validTests, timeout, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate);
+                        runner = new FileSystemTestsRunner(validTests, timeout, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger);
                     }
 
                     break;
@@ -732,5 +734,32 @@ namespace HpToolsLauncher
 
         }
 
+        private SummaryDataLogger GetSummaryDataLogger()
+        {
+            string[] summaryDataLogFlags = _ciParams["SummaryDataLog"].Split(";".ToCharArray());
+            SummaryDataLogger summaryDataLogger;
+            if (summaryDataLogFlags.Length == 4)
+            {
+                int summaryDataLoggerPollingInterval;
+                //If the polling interval is not a valid number, set it to default (10 seconds)
+                if (!Int32.TryParse(summaryDataLogFlags[3], out summaryDataLoggerPollingInterval)) {
+                    summaryDataLoggerPollingInterval = 10;
+                }
+
+                summaryDataLogger = new SummaryDataLogger(
+                    summaryDataLogFlags[0].Equals("1"),
+                    summaryDataLogFlags[1].Equals("1"),
+                    summaryDataLogFlags[2].Equals("1"),
+                    summaryDataLoggerPollingInterval                    
+                );
+            }
+            else
+            {
+                summaryDataLogger = new SummaryDataLogger();
+            }
+            
+            return summaryDataLogger;
+
+        }
     }
 }

--- a/HpToolsLauncher/Properties/Resources.Designer.cs
+++ b/HpToolsLauncher/Properties/Resources.Designer.cs
@@ -160,7 +160,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to problem while setting remote host: {0}.
+        ///   Looks up a localized string similar to Problem while setting remote host: {0}.
         /// </summary>
         internal static string AlmRunnerProblemWithHost {
             get {
@@ -313,7 +313,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No HPE testing tool is installed on {0}.
+        ///   Looks up a localized string similar to No Micro Focus testing tool is installed on {0}.
         /// </summary>
         internal static string FileSystemTestsRunner_No_HP_testing_tool_is_installed_on {
             get {
@@ -574,7 +574,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured while disposing runner: {0}..
+        ///   Looks up a localized string similar to An error occurred while disposing runner: {0}..
         /// </summary>
         internal static string LauncherRunnerDisposeError {
             get {
@@ -637,7 +637,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to initilize Analysis launcher..
+        ///   Looks up a localized string similar to Failed to initialize Analysis launcher..
         /// </summary>
         internal static string LrAnlysisInitFail {
             get {
@@ -772,7 +772,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timeout passed. Stopping sceario by force..
+        ///   Looks up a localized string similar to Timeout passed. Stopping scenario by force..
         /// </summary>
         internal static string LrScenarioEndedTimeOut {
             get {
@@ -781,7 +781,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Errors occured during scenario execution. Stopping the scenario run..
+        ///   Looks up a localized string similar to Errors occurred during scenario execution. Stopping the scenario run..
         /// </summary>
         internal static string LrScenarioEndedWithErrors {
             get {
@@ -898,7 +898,16 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test FAILED. {0} errors occured during scenario execution..
+        ///   Looks up a localized string similar to An error occured during summary data logging: {0}.
+        /// </summary>
+        internal static string LrSummaryDataLoggingError {
+            get {
+                return ResourceManager.GetString("LrSummaryDataLoggingError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test FAILED. {0} errors occurred during scenario execution..
         /// </summary>
         internal static string LRTestFailDueToFatalErrors {
             get {
@@ -916,7 +925,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Setting test state to WARNING. {0} Ignored errors occured during scenario execution..
+        ///   Looks up a localized string similar to Setting test state to WARNING. {0} Ignored errors occurred during scenario execution..
         /// </summary>
         internal static string LRTestWarningDueToIgnoredErrors {
             get {
@@ -1007,7 +1016,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to HPE Testing Tool is missing : HPE Service Test/HPE Unified Function Testing.
+        ///   Looks up a localized string similar to Micro Focus Testing Tool is missing : Micro Focus Service Test/Micro Focus Unified Function Testing.
         /// </summary>
         internal static string STExecuterNotFound {
             get {
@@ -1025,7 +1034,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UFT cannot start while HPE Sprinter is running..
+        ///   Looks up a localized string similar to UFT cannot start while Micro Focus Sprinter is running..
         /// </summary>
         internal static string UFT_Sprinter_Running {
             get {

--- a/HpToolsLauncher/Properties/Resources.resx
+++ b/HpToolsLauncher/Properties/Resources.resx
@@ -445,4 +445,7 @@ Save the test in QuickTest and then run it again.</value>
   <data name="InvalidReportPath" xml:space="preserve">
     <value>Invalid report path provided: '{0}'</value>
   </data>
+  <data name="LrSummaryDataLoggingError" xml:space="preserve">
+    <value>An error occured during summary data logging: {0}</value>
+  </data>
 </root>

--- a/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
+++ b/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
@@ -41,6 +41,7 @@ namespace HpToolsLauncher
         private bool _useUFTLicense;
         private bool _displayController;
         private string _analysisTemplate;
+        private SummaryDataLogger _summaryDataLogger;
         private TimeSpan _timeout = TimeSpan.MaxValue;
         private readonly string _uftRunMode;
         private Stopwatch _stopwatch = null;
@@ -85,9 +86,10 @@ namespace HpToolsLauncher
                                     Dictionary<string, List<string>> parallelRunnerEnvironments,
                                     bool displayController,
                                     string analysisTemplate,
+                                    SummaryDataLogger summaryDataLogger,
                                     bool useUFTLicense = false)
 
-            :this(sources, timeout, ControllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, parallelRunnerEnvironments, displayController, analysisTemplate, useUFTLicense)
+            :this(sources, timeout, ControllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, useUFTLicense)
         {
             _uftRunMode = uftRunMode;
         }
@@ -110,6 +112,7 @@ namespace HpToolsLauncher
                                     Dictionary<string, List<string>> parallelRunnerEnvironments,
                                     bool displayController,
                                     string analysisTemplate,
+                                    SummaryDataLogger summaryDataLogger,
                                     bool useUFTLicense = false)
         {
             _jenkinsEnvVariables = jenkinsEnvVariables;
@@ -131,6 +134,7 @@ namespace HpToolsLauncher
             _useUFTLicense = useUFTLicense;
             _displayController = displayController;
             _analysisTemplate = analysisTemplate;
+            _summaryDataLogger = summaryDataLogger;
             _tests = new List<TestInfo>();
 
             _mcConnection = mcConnection;
@@ -369,7 +373,7 @@ namespace HpToolsLauncher
                     break;
                 case TestType.LoadRunner:
                     AppDomain.CurrentDomain.AssemblyResolve += Helper.HPToolsAssemblyResolver;
-                    runner = new PerformanceTestRunner(this, _timeout, _pollingInterval, _perScenarioTimeOutMinutes, _ignoreErrorStrings, _displayController, _analysisTemplate);
+                    runner = new PerformanceTestRunner(this, _timeout, _pollingInterval, _perScenarioTimeOutMinutes, _ignoreErrorStrings, _displayController, _analysisTemplate, _summaryDataLogger);
                     break;
                 case TestType.ParallelRunner:
                     runner = new ParallelTestRunner(this, _timeout - _stopwatch.Elapsed, _mcConnection, _mobileInfoForAllGuiTests, _parallelRunnerEnvironments);

--- a/HpToolsLauncher/TestRunners/SummaryDataLogger.cs
+++ b/HpToolsLauncher/TestRunners/SummaryDataLogger.cs
@@ -1,0 +1,152 @@
+﻿/*
+ *
+ *  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+ *  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+ *  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+ *  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+ *  marks are the property of their respective owners.
+ * __________________________________________________________________
+ * MIT License
+ *
+ * © Copyright 2012-2018 Micro Focus or one of its affiliates.
+ *
+ * The only warranties for products and services of Micro Focus and its affiliates
+ * and licensors (“Micro Focus”) are set forth in the express warranty statements
+ * accompanying such products and services. Nothing herein should be construed as
+ * constituting an additional warranty. Micro Focus shall not be liable for technical
+ * or editorial errors or omissions contained herein.
+ * The information contained herein is subject to change without notice.
+ * ___________________________________________________________________
+ *
+ */
+ 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using HP.LoadRunner.Interop.Wlrun;
+
+namespace HpToolsLauncher.TestRunners
+{
+    public class SummaryDataLogger
+    {
+        private bool m_logVusersStates;
+        private bool m_logErrorCount;
+        private bool m_logTransactionStatistics;
+        private int m_pollingInterval;
+
+        public SummaryDataLogger(bool logVusersStates, bool logErrorCount, bool logTransactionStatistics, int pollingInterval)
+        {
+            m_logVusersStates = logVusersStates;
+            m_logErrorCount = logErrorCount;
+            m_logTransactionStatistics = logTransactionStatistics;
+            m_pollingInterval = pollingInterval;
+        }
+
+        public SummaryDataLogger() { }
+
+        public int GetPollingInterval()
+        {
+            return m_pollingInterval * 1000;
+        }
+
+        private enum VUSERS_STATE
+        {
+            Down = 1,
+            Pending = 2,
+            Init = 3,
+            Ready = 4,
+            Run = 5,
+            Rendez = 6,
+            Passed = 7,
+            Failed = 8,
+            Error = 9,
+            Exiting = 10,
+            Stopped = 11,
+            G_Exit = 12 //Gradual Exiting
+        }
+
+        private void LogVuserStates(LrScenario scenario)
+        {
+            StringBuilder headerBuilder = new StringBuilder(),
+                          bodyBuilder = new StringBuilder();
+
+            foreach (var vuserState in Enum.GetValues(typeof(VUSERS_STATE)))
+            {
+                headerBuilder.Append(string.Format("{0, -10}", vuserState.ToString()));
+            }
+            
+            foreach (var vuserState in Enum.GetValues(typeof(VUSERS_STATE)))
+            {
+                bodyBuilder.Append(string.Format("{0, -10}", scenario.GetVusersCount((int)vuserState)));
+            }
+
+            ConsoleWriter.WriteLine(headerBuilder.ToString());
+            ConsoleWriter.WriteLine(bodyBuilder.ToString());
+        }
+
+        private void LogErrorCount(LrScenario scenario)
+        {
+
+            int errorsCount = scenario.GetErrorsCount("");
+
+            ConsoleWriter.WriteLine("Error count: "+ errorsCount);
+        }
+
+        private void LogScenarioDuration(LrScenario scenario)
+        {
+            int scenarioDuration = scenario.ScenarioDuration;
+            TimeSpan time = TimeSpan.FromSeconds(scenarioDuration);
+            string convertedTime = time.ToString(@"dd\:hh\:mm\:ss");
+
+            ConsoleWriter.WriteLine("Elapsed Time (D:H:M:S): " + convertedTime);
+        }
+
+        public void LogSummaryData(LrScenario scenario)
+        {
+            if (m_logVusersStates || m_logErrorCount || m_logTransactionStatistics)
+            {
+                LogScenarioDuration(scenario);
+
+                if (m_logVusersStates)
+                {
+                    LogVuserStates(scenario);
+                }
+
+                if (m_logErrorCount)
+                {
+                    LogErrorCount(scenario);
+                }
+
+                if (m_logTransactionStatistics)
+                {
+                    LogTransactionStatistics(scenario);
+                }
+            }
+        }
+
+        public bool IsAnyDataLogged()
+        {
+            return (m_logVusersStates || m_logErrorCount || m_logTransactionStatistics);
+        }
+
+        private void LogTransactionStatistics(LrScenario scenario)
+        {
+            int passed = 0, failed = 0;
+            double hitsPerSecond = 0;
+            scenario.GetTransactionStatistics(ref passed, ref failed, ref hitsPerSecond);
+
+            ConsoleWriter.WriteLine("Passed transactions: " + passed);
+            ConsoleWriter.WriteLine("Failed transactions: " + failed);
+            ConsoleWriter.WriteLine("Hits per second: " + Math.Round(hitsPerSecond, 2));
+        }
+
+        public void LogTransactionDetails(LrScenario scenario)
+        {
+            string transactionDetails;
+            scenario.GetTransactionStatisticsDetails(out transactionDetails);
+
+            ConsoleWriter.WriteLine("Transaction details: " + transactionDetails);
+        }
+    }
+}

--- a/src/main/java/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel.java
+++ b/src/main/java/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel.java
@@ -1,0 +1,93 @@
+/*
+ *
+ *  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+ *  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+ *  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+ *  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+ *  marks are the property of their respective owners.
+ * __________________________________________________________________
+ * MIT License
+ *
+ * © Copyright 2012-2018 Micro Focus or one of its affiliates.
+ *
+ * The only warranties for products and services of Micro Focus and its affiliates
+ * and licensors (“Micro Focus”) are set forth in the express warranty statements
+ * accompanying such products and services. Nothing herein should be construed as
+ * constituting an additional warranty. Micro Focus shall not be liable for technical
+ * or editorial errors or omissions contained herein.
+ * The information contained herein is subject to change without notice.
+ * ___________________________________________________________________
+ *
+ */
+
+package com.microfocus.application.automation.tools.lr.model;
+
+import com.microfocus.application.automation.tools.lr.Messages;
+import hudson.Extension;
+import hudson.util.FormValidation;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import javax.annotation.Nonnull;
+import java.util.Properties;
+
+public class SummaryDataLogModel extends AbstractDescribableImpl<SummaryDataLogModel> {
+    private boolean logVusersStates;
+    private boolean logErrorCount;
+    private boolean logTransactionStatistics;
+    private String pollingInterval;
+
+    @DataBoundConstructor
+    public SummaryDataLogModel(boolean logVusersStates, boolean logErrorCount, boolean logTransactionStatistics, String pollingInterval) {
+        this.logVusersStates = logVusersStates;
+        this.logErrorCount = logErrorCount;
+        this.logTransactionStatistics = logTransactionStatistics;
+        this.pollingInterval = pollingInterval;
+    }
+
+    public boolean getLogVusersStates() {
+        return logVusersStates;
+    }
+
+    public boolean getLogErrorCount() {
+        return logErrorCount;
+    }
+
+    public boolean getLogTransactionStatistics() {
+        return logTransactionStatistics;
+    }
+
+    public String getPollingInterval() { return pollingInterval; }
+
+    public void addToProps(Properties props)
+    {
+        if (StringUtils.isEmpty(pollingInterval))
+        {
+            pollingInterval = "30";
+        }
+
+        props.put("SummaryDataLog",
+                BooleanUtils.toInteger(logVusersStates) + ";"
+                + BooleanUtils.toInteger(logErrorCount) + ";"
+                + BooleanUtils.toInteger(logTransactionStatistics) + ";"
+                + Integer.parseInt(pollingInterval)
+        );
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SummaryDataLogModel> {
+        @Nonnull
+        public String getDisplayName() { return Messages.SummaryDataLogModel(); }
+
+        public FormValidation doCheckPollingInterval(@QueryParameter String value) {
+            if (!StringUtils.isNumeric(value)) {
+                return FormValidation.error("Polling Interval must be a number");
+            }
+
+            return FormValidation.ok();
+        }
+    }
+}

--- a/src/main/java/com/microfocus/application/automation/tools/pipelineSteps/LoadRunnerTestStep.java
+++ b/src/main/java/com/microfocus/application/automation/tools/pipelineSteps/LoadRunnerTestStep.java
@@ -24,6 +24,7 @@ package com.microfocus.application.automation.tools.pipelineSteps;
 
 import com.microfocus.application.automation.tools.model.EnumDescription;
 import com.microfocus.application.automation.tools.model.ResultsPublisherModel;
+import com.microfocus.application.automation.tools.lr.model.SummaryDataLogModel;
 import com.microfocus.application.automation.tools.results.RunResultRecorder;
 import com.microfocus.application.automation.tools.run.RunFromFileBuilder;
 import hudson.Extension;
@@ -193,6 +194,14 @@ public class LoadRunnerTestStep extends AbstractStepImpl {
         runFromFileBuilder.setDisplayController(displayController);
     }
 
+    public SummaryDataLogModel getSummaryDataLogModel() {
+        return runFromFileBuilder.getSummaryDataLogModel();
+    }
+
+    @DataBoundSetter
+    public void setSummaryDataLogModel(SummaryDataLogModel summaryDataLogModel) {
+        runFromFileBuilder.setSummaryDataLogModel(summaryDataLogModel);
+    }
     /**
      * Gets run from file builder.
      *

--- a/src/main/java/com/microfocus/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/run/RunFromFileBuilder.java
@@ -31,6 +31,7 @@ import com.microfocus.application.automation.tools.model.MCServerSettingsModel;
 import com.microfocus.application.automation.tools.model.ProxySettings;
 import com.microfocus.application.automation.tools.model.RunFromFileSystemModel;
 import com.microfocus.application.automation.tools.settings.MCServerSettingsBuilder;
+import com.microfocus.application.automation.tools.lr.model.SummaryDataLogModel;
 import hudson.*;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
@@ -70,6 +71,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
     private RunFromFileSystemModel runFromFileModel;
     private FileSystemTestSetModel fileSystemTestSetModel;
     private boolean isParallelRunnerEnabled;
+    private SummaryDataLogModel summaryDataLogModel;
 
     /**
      * Instantiates a new Run from file builder.
@@ -78,10 +80,12 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
      */
     @DataBoundConstructor
     public RunFromFileBuilder(String fsTests, boolean isParallelRunnerEnabled,
-                              FileSystemTestSetModel fileSystemTestSetModel) {
+                              FileSystemTestSetModel fileSystemTestSetModel,
+                              SummaryDataLogModel summaryDataLogModel) {
         this.runFromFileModel = new RunFromFileSystemModel(fsTests);
         this.fileSystemTestSetModel = fileSystemTestSetModel;
         this.isParallelRunnerEnabled = isParallelRunnerEnabled;
+        this.summaryDataLogModel = summaryDataLogModel;
     }
 
 
@@ -242,6 +246,12 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
     @DataBoundSetter
     public void setAnalysisTemplate(String analysisTemplate) {
         runFromFileModel.setAnalysisTemplate(analysisTemplate);
+    }
+
+    public SummaryDataLogModel getSummaryDataLogModel() { return summaryDataLogModel; }
+
+    public void setSummaryDataLogModel(SummaryDataLogModel summaryDataLogModel) {
+        this.summaryDataLogModel = summaryDataLogModel;
     }
 
     public String getFsTimeout() {
@@ -634,6 +644,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
         ResultFilename = "Results" + time + ".xml";
 
         mergedProperties.put("runType", AlmRunTypes.RunType.FileSystem.toString());
+        summaryDataLogModel.addToProps(mergedProperties);
         mergedProperties.put("resultsFilename", ResultFilename);
 
         // parallel runner is enabled

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/Messages.properties
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/Messages.properties
@@ -19,3 +19,4 @@
 #
 
 ProductName=LoadRunner
+SummaryDataLogModel=Summary Data Log Model

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/config.jelly
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/config.jelly
@@ -1,0 +1,38 @@
+<!--
+  ~
+  ~  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+  ~  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+  ~  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+  ~  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+  ~  marks are the property of their respective owners.
+  ~ __________________________________________________________________
+  ~ MIT License
+  ~
+  ~ © Copyright 2012-2018 Micro Focus or one of its affiliates.
+  ~
+  ~ The only warranties for products and services of Micro Focus and its affiliates
+  ~ and licensors (“Micro Focus”) are set forth in the express warranty statements
+  ~ accompanying such products and services. Nothing herein should be construed as
+  ~ constituting an additional warranty. Micro Focus shall not be liable for technical
+  ~ or editorial errors or omissions contained herein.
+  ~ The information contained herein is subject to change without notice.
+  ~ ___________________________________________________________________
+  ~
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:cv="/lib/custom">
+
+    <f:entry title="${%PollingInterval}" field="pollingInterval">
+        <f:textbox name="pollingInterval" value="${instance.pollingInterval}" default=""/>
+    </f:entry>
+    <f:entry title="${%LogVusersStates}" field="logVusersStates">
+        <f:checkbox name="logVusersStates" checked="${instance.logVusersStates}"/>
+    </f:entry>
+    <f:entry title="${%LogErrorCount}" field="logErrorCount">
+        <f:checkbox name="logErrorCount" checked="${instance.logErrorCount}"/>
+    </f:entry>
+    <f:entry title="${%LogTransactionStatistics}" field="logTransactionStatistics">
+        <f:checkbox name="logTransactionStatistics" checked="${instance.logTransactionStatistics}"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/config.properties
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/config.properties
@@ -20,7 +20,7 @@
 #
 #
 
-DontForgetThePublisher=Make sure to enable the <strong>Publish Micro Focus \
-    tests result</strong> option in the <strong>Post-build \
-    Actions</strong> section. This allows the tests results to be published.
-SummaryDataLog=Summary Data Log
+PollingInterval=Polling Interval
+LogVusersStates=Log Vusers States
+LogErrorCount=Log Error Count
+LogTransactionStatistics=Log Transaction Statistics

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-logErrorCount.html
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-logErrorCount.html
@@ -1,0 +1,25 @@
+<!--
+  ~
+  ~  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+  ~  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+  ~  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+  ~  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+  ~  marks are the property of their respective owners.
+  ~ __________________________________________________________________
+  ~ MIT License
+  ~
+  ~ © Copyright 2012-2018 Micro Focus or one of its affiliates.
+  ~
+  ~ The only warranties for products and services of Micro Focus and its affiliates
+  ~ and licensors (“Micro Focus”) are set forth in the express warranty statements
+  ~ accompanying such products and services. Nothing herein should be construed as
+  ~ constituting an additional warranty. Micro Focus shall not be liable for technical
+  ~ or editorial errors or omissions contained herein.
+  ~ The information contained herein is subject to change without notice.
+  ~ ___________________________________________________________________
+  ~
+  -->
+
+<div>
+    Display the number of controller errors.
+</div>

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-logTransactionStatistics.html
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-logTransactionStatistics.html
@@ -1,0 +1,25 @@
+<!--
+  ~
+  ~  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+  ~  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+  ~  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+  ~  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+  ~  marks are the property of their respective owners.
+  ~ __________________________________________________________________
+  ~ MIT License
+  ~
+  ~ © Copyright 2012-2018 Micro Focus or one of its affiliates.
+  ~
+  ~ The only warranties for products and services of Micro Focus and its affiliates
+  ~ and licensors (“Micro Focus”) are set forth in the express warranty statements
+  ~ accompanying such products and services. Nothing herein should be construed as
+  ~ constituting an additional warranty. Micro Focus shall not be liable for technical
+  ~ or editorial errors or omissions contained herein.
+  ~ The information contained herein is subject to change without notice.
+  ~ ___________________________________________________________________
+  ~
+  -->
+
+<div>
+    Display the number of passed transactions, failed transactions and hits per second.
+</div>

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-logVusersStates.html
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-logVusersStates.html
@@ -1,0 +1,25 @@
+<!--
+  ~
+  ~  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+  ~  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+  ~  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+  ~  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+  ~  marks are the property of their respective owners.
+  ~ __________________________________________________________________
+  ~ MIT License
+  ~
+  ~ © Copyright 2012-2018 Micro Focus or one of its affiliates.
+  ~
+  ~ The only warranties for products and services of Micro Focus and its affiliates
+  ~ and licensors (“Micro Focus”) are set forth in the express warranty statements
+  ~ accompanying such products and services. Nothing herein should be construed as
+  ~ constituting an additional warranty. Micro Focus shall not be liable for technical
+  ~ or editorial errors or omissions contained herein.
+  ~ The information contained herein is subject to change without notice.
+  ~ ___________________________________________________________________
+  ~
+  -->
+
+<div>
+    Display the number of virtual users in each state.
+</div>

--- a/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-pollingInterval.html
+++ b/src/main/resources/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel/help-pollingInterval.html
@@ -1,0 +1,25 @@
+<!--
+  ~
+  ~  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
+  ~  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
+  ~  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+  ~  and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+  ~  marks are the property of their respective owners.
+  ~ __________________________________________________________________
+  ~ MIT License
+  ~
+  ~ © Copyright 2012-2018 Micro Focus or one of its affiliates.
+  ~
+  ~ The only warranties for products and services of Micro Focus and its affiliates
+  ~ and licensors (“Micro Focus”) are set forth in the express warranty statements
+  ~ accompanying such products and services. Nothing herein should be construed as
+  ~ constituting an additional warranty. Micro Focus shall not be liable for technical
+  ~ or editorial errors or omissions contained herein.
+  ~ The information contained herein is subject to change without notice.
+  ~ ___________________________________________________________________
+  ~
+  -->
+
+<div>
+    The rate at which the messages are displayed (in seconds). Default value is 10 seconds.
+</div>

--- a/src/main/resources/com/microfocus/application/automation/tools/pipelineSteps/LoadRunnerTestStep/config.jelly
+++ b/src/main/resources/com/microfocus/application/automation/tools/pipelineSteps/LoadRunnerTestStep/config.jelly
@@ -58,6 +58,11 @@
             <f:entry title="Display Controller" field="displayController">
                 <f:checkbox name="runPipeline.displayController"/>
             </f:entry>
+            <f:section title="${%SummaryDataLog}">
+                <f:entry name="Summary Data Log Model" field="summaryDataLogModel">
+                    <f:property field="summaryDataLogModel" />
+                </f:entry>
+            </f:section>
         </f:advanced>
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/microfocus/application/automation/tools/run/RunFromFileBuilder/config.jelly
+++ b/src/main/resources/com/microfocus/application/automation/tools/run/RunFromFileBuilder/config.jelly
@@ -90,13 +90,19 @@
 			<f:entry title="Errors to Ignore" field="ignoreErrorStrings">
 				<f:textarea name="runfromfs.ignoreErrorStrings" value="${instance.runFromFileModel.ignoreErrorStrings}"  />
 			</f:entry>
-      <f:entry title="Analysis Template" field="analysisTemplate">
-        <f:textbox name="runPipeline.analysisTemplate" value="${instance.runFromFileModel.analysisTemplate}" default=""/>
-      </f:entry>
-			<f:entry title="Display Controller" field="displayController">
-        <f:checkbox name="runfromfs.displayController" checked="${instance.runFromFileModel.displayController}"/>
-      </f:entry>
-    	</f:section>
+            <f:entry title="Analysis Template" field="analysisTemplate">
+                <f:textbox name="runPipeline.analysisTemplate" value="${instance.runFromFileModel.analysisTemplate}" default=""/>
+            </f:entry>
+            <f:entry title="Display Controller" field="displayController">
+                <f:checkbox name="runfromfs.displayController" checked="${instance.runFromFileModel.displayController}"/>
+            </f:entry>
+            <f:section title="Summary Data Log">
+                <f:entry name="Summary Data Log Model" field="summaryDataLogModel">
+                    <f:property field="summaryDataLogModel" />
+                </f:entry>
+            </f:section>
+
+        </f:section>
     </f:advanced>
 
     <!-- add MC server and app info starting -->


### PR DESCRIPTION
Ticket: JENKINS-47997, JENKINS-53163, JENKINS-53703 (similar improvements, added metrics display during scenario execution)
Added summary data logging during scenario run for:
-> error count
-> vuser states
-> passed/failed transactions & hits per second

Logging Flags and polling interval can be set by user. Available in both freestyle & pipeline builds.