### PR TITLE
Fix backwards compatibility

### DIFF
--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -738,23 +738,32 @@ namespace HpToolsLauncher
 
         private SummaryDataLogger GetSummaryDataLogger()
         {
-            string[] summaryDataLogFlags = _ciParams["SummaryDataLog"].Split(";".ToCharArray());
             SummaryDataLogger summaryDataLogger;
-            if (summaryDataLogFlags.Length == 4)
-            {
-                int summaryDataLoggerPollingInterval;
-                //If the polling interval is not a valid number, set it to default (10 seconds)
-                if (!Int32.TryParse(summaryDataLogFlags[3], out summaryDataLoggerPollingInterval))
-                {
-                    summaryDataLoggerPollingInterval = 10;
-                }
 
-                summaryDataLogger = new SummaryDataLogger(
-                    summaryDataLogFlags[0].Equals("1"),
-                    summaryDataLogFlags[1].Equals("1"),
-                    summaryDataLogFlags[2].Equals("1"),
-                    summaryDataLoggerPollingInterval
-                );
+            if (_ciParams.ContainsKey("SummaryDataLog"))
+            {
+                string[] summaryDataLogFlags = _ciParams["SummaryDataLog"].Split(";".ToCharArray());
+
+                if (summaryDataLogFlags.Length == 4)
+                {
+                    int summaryDataLoggerPollingInterval;
+                    //If the polling interval is not a valid number, set it to default (10 seconds)
+                    if (!Int32.TryParse(summaryDataLogFlags[3], out summaryDataLoggerPollingInterval))
+                    {
+                        summaryDataLoggerPollingInterval = 10;
+                    }
+
+                    summaryDataLogger = new SummaryDataLogger(
+                        summaryDataLogFlags[0].Equals("1"),
+                        summaryDataLogFlags[1].Equals("1"),
+                        summaryDataLogFlags[2].Equals("1"),
+                        summaryDataLoggerPollingInterval
+                    );
+                }
+                else
+                {
+                    summaryDataLogger = new SummaryDataLogger();
+                }
             }
             else
             {

--- a/src/main/java/com/microfocus/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/run/RunFromFileBuilder.java
@@ -654,8 +654,13 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
         ResultFilename = "Results" + time + ".xml";
 
         mergedProperties.put("runType", AlmRunTypes.RunType.FileSystem.toString());
-        summaryDataLogModel.addToProps(mergedProperties);
-        scriptRTSSetModel.addScriptsToProps(mergedProperties);
+
+        if (summaryDataLogModel != null) {
+            summaryDataLogModel.addToProps(mergedProperties);
+        }
+        if (scriptRTSSetModel != null) {
+            scriptRTSSetModel.addScriptsToProps(mergedProperties);
+        }
         mergedProperties.put("resultsFilename", ResultFilename);
 
         // parallel runner is enabled


### PR DESCRIPTION
Ticket: JENKINS-54314
Use case #1. Pipeline build from 5.5 will fail due to error (the new models are not initialized).
Use case #2. No RTS specified in 5.6 causes the build to fail due to error (the RTS model is not initialized).
Use case #3. HpToolsLauncher.exe doesn't find in paramfile the key: summarydatalog
