### PR TITLE
[JENKINS-53003] Timeout crash & improve logging

### DIFF
--- a/HpToolsLauncher/Properties/Resources.Designer.cs
+++ b/HpToolsLauncher/Properties/Resources.Designer.cs
@@ -808,7 +808,7 @@ namespace HpToolsLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Scenario Execution timeout ({0} seconds) passed..
+        ///   Looks up a localized string similar to Scenario Execution timeout {0} (d:h:m:s) passed..
         /// </summary>
         internal static string LrScenarioTimeOut {
             get {

--- a/HpToolsLauncher/Properties/Resources.resx
+++ b/HpToolsLauncher/Properties/Resources.resx
@@ -368,7 +368,7 @@ Save the test in QuickTest and then run it again.</value>
     <value>Errors occurred during scenario execution. Stopping the scenario run.</value>
   </data>
   <data name="LrScenarioTimeOut" xml:space="preserve">
-    <value>Scenario Execution timeout ({0} seconds) passed.</value>
+    <value>Scenario Execution timeout {0} (d:h:m:s) passed.</value>
   </data>
   <data name="LrScenarioValidationCannotConnectLG" xml:space="preserve">
     <value>Cannot connect to Load Generator {0}.</value>

--- a/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
+++ b/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
@@ -266,6 +266,7 @@ namespace HpToolsLauncher
                         runResult.TestState = TestState.Error;
                         runResult.ErrorDesc = ex.Message;
                         runResult.TestName = test.TestName;
+                        runResult.TestPath = test.TestPath;
                     }
 
                     //get the original source for this test, for grouping tests under test classes

--- a/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
+++ b/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
@@ -859,7 +859,7 @@ namespace HpToolsLauncher.TestRunners
             catch
             {
                 ConsoleWriter.WriteErrLine("Lost connection to Controller");
-                return isFinished;
+                return true;
             }
 
             isFinished = _vuserStatus[(int)VuserStatus.Down] == 0 &&

--- a/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
+++ b/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
@@ -715,11 +715,10 @@ namespace HpToolsLauncher.TestRunners
             if (_stopWatch.Elapsed > _perScenarioTimeOutMinutes)
             {
                 _stopWatch.Stop();
-                ConsoleWriter.WriteErrLine(string.Format(Resources.LrScenarioTimeOut, _stopWatch.Elapsed.Seconds));
-                errorReason = string.Format(Resources.LrScenarioTimeOut, _stopWatch.Elapsed.Seconds);
+                errorReason = string.Format(Resources.LrScenarioTimeOut, _stopWatch.Elapsed.ToString("dd\\:hh\\:mm\\:ss"));
+                ConsoleWriter.WriteErrLine(errorReason);
             }
-
-
+            
             if (_scenarioEndedEvent)
             {
                 try
@@ -734,9 +733,6 @@ namespace HpToolsLauncher.TestRunners
             //if scenario not ended until now, force stop it.
             if (!_scenarioEnded)
             {
-
-                ConsoleWriter.WriteErrLine(Resources.LrScenarioTimeOut);
-
                 int ret = _engine.Scenario.StopNow();
                 if (ret != 0)
                 {
@@ -855,8 +851,16 @@ namespace HpToolsLauncher.TestRunners
 
         private bool isFinished()
         {
-            updateVuserStatus();
             bool isFinished = false;
+            try
+            {
+                updateVuserStatus();
+            }
+            catch
+            {
+                ConsoleWriter.WriteErrLine("Lost connection to Controller");
+                return isFinished;
+            }
 
             isFinished = _vuserStatus[(int)VuserStatus.Down] == 0 &&
                          _vuserStatus[(int)VuserStatus.Pending] == 0 &&


### PR DESCRIPTION
JENKINS-53003
- if scenario timeout is reached, sometimes controller becomes unresponsive and exception is thrown
- catch the exception and continue the normal flow

Logging
- scenario path was not displayed on some use cases
- scenario timeout was displayed wrongly