### PR TITLE
 Update Jenkins supported version to 2.89.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.14</version>
+		<version>2.30</version>
 	</parent>
 
 	<artifactId>hp-application-automation-tools-plugin</artifactId>
@@ -50,7 +50,7 @@
 		<concurrency>1</concurrency>
 		<msbuild.exe>C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe</msbuild.exe>
 		<msbuild.configuration>Release</msbuild.configuration>
-		<jenkins.version>2.60.3</jenkins.version>
+		<jenkins.version>2.89.4</jenkins.version>
 		<maven.exec.skip>false</maven.exec.skip>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
- [ ] Proper Jira ticket - Number, Link in pull request description.

Jenkins version 2.89.4 does not have war-test-harness, hence it was required to update the parent pom to 2.30 which doesn't require it as well.