### PR TITLE
Octane fixes 5.8.7(2)

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/TestExecutionJobCreatorService.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/TestExecutionJobCreatorService.java
@@ -483,6 +483,7 @@ public class TestExecutionJobCreatorService {
 					Pattern p = Pattern.compile("[^\\w]");
 					Matcher m = p.matcher(label);
 					if (m.find()){
+						//if contain non-letter/digit character, wrap with "
 						label = "\"" + label + "\"";
 					}
 					labels.add(label);
@@ -490,8 +491,14 @@ public class TestExecutionJobCreatorService {
 			}
 
 			if (!labels.isEmpty()) {
-				Label joinedLabel = Label.parseExpression(StringUtils.join(labels, "||"));
-				proj.setAssignedLabel(joinedLabel);
+				String joined = StringUtils.join(labels, "||");
+				//if there are more than 1 wrapped label (for example : "label 1"), need to wrap it with parentheses
+				boolean parenthesesRequired = labels.stream().filter(l -> l.startsWith("\"")).count() > 1;
+				if (parenthesesRequired) {
+					joined = "(" + joined + ")";
+				}
+
+				proj.setAssignedLabel(Label.parseExpression(joined));
 			}
 
 		} catch (IOException | ANTLRException e) {


### PR DESCRIPTION
[JENKINS-59174 : UFT executor job created without UFT slave label , because of existence of non-letter characters in slave name](https://issues.jenkins-ci.org/browse/JENKINS-59174)