### PR TITLE
Octane 6.1.4-beta

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel.java
+++ b/src/main/java/com/microfocus/application/automation/tools/lr/model/SummaryDataLogModel.java
@@ -26,7 +26,7 @@ import hudson.util.FormValidation;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang.BooleanUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import javax.annotation.Nonnull;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/CIJenkinsServicesImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/CIJenkinsServicesImpl.java
@@ -72,7 +72,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitTestResult.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitTestResult.java
@@ -20,6 +20,7 @@
 
 package com.microfocus.application.automation.tools.octane.tests.junit;
 
+import com.hp.octane.integrations.utils.SdkStringUtils;
 import com.microfocus.application.automation.tools.octane.tests.testResult.TestResult;
 
 import javax.xml.stream.XMLStreamException;
@@ -117,7 +118,7 @@ final public class JUnitTestResult implements Serializable, TestResult {
             writer.writeAttribute("message", String.valueOf(testError.getErrorMsg()));
             writer.writeCharacters(testError.getStackTraceStr());
             writer.writeEndElement();
-        } else if (testError != null && testError.getErrorMsg() != null) {//warning case
+        } else if (testError != null && !SdkStringUtils.isEmpty(testError.getErrorMsg())) {//warning case
             writer.writeStartElement("error");
             writer.writeAttribute("message", String.valueOf(testError.getErrorMsg()));
             writer.writeEndElement();


### PR DESCRIPTION
[JENKINS-61362 : avoid using of library "org.apache.commons.lang3." as it might not be on customer environment](https://issues.jenkins-ci.org/browse/JENKINS-61362)

tech : don't add error element in MqmTests.xml for test run if errorMsg==""