### PR TITLE
GetValidTests returning null will crash app

### DIFF
--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -1027,7 +1027,7 @@ namespace HpToolsLauncher
                 ConsoleWriter.WriteLine(errorNoValidTests);
             }
 
-            return null;
+            return new List<TestData>();
         }
 
         /// <summary>


### PR DESCRIPTION
[JENKINS-61836 - Job shows Load Runner controller is still running. Can't shutdown gracefully](https://issues.jenkins-ci.org/browse/JENKINS-61836?jql=project%20%3D%20JENKINS%20ORDER%20BY%20created%20DESC)