### PR TITLE
Setting UTF8 encoding in test report upload

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/sse/sdk/Response.java
+++ b/src/main/java/com/microfocus/application/automation/tools/sse/sdk/Response.java
@@ -122,6 +122,6 @@ public class Response {
     @Override
     public String toString() {
         
-        return new String(_data);
+        return new String(_data, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/microfocus/application/automation/tools/sse/sdk/request/GeneralPostRequest.java
+++ b/src/main/java/com/microfocus/application/automation/tools/sse/sdk/request/GeneralPostRequest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Created by barush on 29/10/2014.

--- a/src/main/java/com/microfocus/application/automation/tools/sse/sdk/request/GeneralPostRequest.java
+++ b/src/main/java/com/microfocus/application/automation/tools/sse/sdk/request/GeneralPostRequest.java
@@ -76,7 +76,7 @@ public abstract class GeneralPostRequest extends GeneralRequest {
             builder.append(RestXmlUtils.fieldXml(currPair.getFirst(), currPair.getSecond()));
         }
         
-        return builder.append("</Fields></Entity>").toString().getBytes();
+        return builder.append("</Fields></Entity>").toString().getBytes(StandardCharsets.UTF_8);
     }
     
     protected List<Pair<String, String>> getDataFields() {


### PR DESCRIPTION
Hello,

Setting the UTF8 encoding is necessary in order to upload JUnit report with accented characters.
Otherwise, the report upload fails.
