### PR TITLE
DEF-735118 & US-740059

### DIFF
--- a/HpToolsLauncher/JunitXml/junit.cs
+++ b/HpToolsLauncher/JunitXml/junit.cs
@@ -420,11 +420,11 @@ public partial class testsuite
 
     private string nameField;
 
-    private string testsField;
+    private int testsField;
 
-    private string failuresField;
+    private int failuresField;
 
-    private string errorsField;
+    private int errorsField;
 
     private string timeField;
 
@@ -513,7 +513,7 @@ public partial class testsuite
 
     /// <remarks/>
     [System.Xml.Serialization.XmlAttributeAttribute()]
-    public string tests
+    public int tests
     {
         get
         {
@@ -527,7 +527,7 @@ public partial class testsuite
 
     /// <remarks/>
     [System.Xml.Serialization.XmlAttributeAttribute()]
-    public string failures
+    public int failures
     {
         get
         {
@@ -541,7 +541,7 @@ public partial class testsuite
 
     /// <remarks/>
     [System.Xml.Serialization.XmlAttributeAttribute()]
-    public string errors
+    public int errors
     {
         get
         {
@@ -797,5 +797,23 @@ public partial class testsuites
 
         if (foundSuite != null)
             testsuiteField.Remove(foundSuite);
+    }
+
+    internal testsuite GetTestSuiteOrDefault(string name, string package, out bool isNewTestSuite)
+    {
+        isNewTestSuite = false;
+        foreach (testsuite ts in testsuiteField)
+            if (ts.name == name && ts.package == package)
+                return ts;
+
+        isNewTestSuite = true;
+        return new testsuite
+        {
+            name = name,
+            package = package,
+            tests = 0,
+            errors = 0,
+            failures = 0
+        };
     }
 }

--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -362,7 +362,7 @@ namespace HpToolsLauncher
                     ConsoleWriter.WriteLine(string.Format(Resources.LauncherDisplayRunmode, enmQcRunMode.ToString()));
 
                     //go over test sets in the parameters, and collect them
-                    List<string> sets = GetParamsWithPrefix("TestSet");
+                    List<string> sets = GetParamsWithPrefix("TestSet", true);
 
                     if (sets.Count == 0)
                     {
@@ -817,7 +817,7 @@ namespace HpToolsLauncher
             }
         }
 
-        private List<string> GetParamsWithPrefix(string prefix)
+        private List<string> GetParamsWithPrefix(string prefix, bool skipEmptyEntries = false)
         {
             int idx = 1;
             List<string> parameters = new List<string>();
@@ -826,8 +826,11 @@ namespace HpToolsLauncher
                 string set = _ciParams[prefix + idx];
                 if (set.StartsWith("Root\\"))
                     set = set.Substring(5);
-                set = set.TrimEnd("\\".ToCharArray());
-                parameters.Add(set.TrimEnd());
+                set = set.TrimEnd(" \\".ToCharArray());
+                if (!(skipEmptyEntries && string.IsNullOrWhiteSpace(set)))
+                {
+                    parameters.Add(set);
+                }
                 ++idx;
             }
             return parameters;
@@ -844,9 +847,9 @@ namespace HpToolsLauncher
                 string set = _ciParams[prefix + idx];
                 if (set.StartsWith("Root\\"))
                     set = set.Substring(5);
-                set = set.TrimEnd("\\".ToCharArray());
+                set = set.TrimEnd(" \\".ToCharArray());
                 string key = prefix + idx;
-                dict[key] = set.TrimEnd();
+                dict[key] = set;
                 ++idx;
             }
 

--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -256,7 +256,6 @@ namespace HpToolsLauncher
 
             List<TestData> failedTests = new List<TestData>();
 
-
             //run the entire set of test once
             //create the runner according to type
             IAssetRunner runner = CreateRunner(_runType, true, failedTests);
@@ -271,9 +270,9 @@ namespace HpToolsLauncher
 
             TestSuiteRunResults results = runner.Run();
 
-            if (!_runType.Equals(TestStorageType.MBT))
+            if (_runType != TestStorageType.MBT)
             {
-                RunTests(runner, resultsFilename, results);
+                RunSummary(runner, resultsFilename, results);
             }
 
             if (_runType.Equals(TestStorageType.FileSystem))
@@ -295,11 +294,12 @@ namespace HpToolsLauncher
                         if (item.TestState == TestState.Failed || item.TestState == TestState.Error)
                         {
                             index++;
-                            failedTests.Add(new TestData(item.TestPath, "FailedTest" + index));
+                            failedTests.Add(new TestData(item.TestPath, string.Format("FailedTest{0}", index)));
                         }
                     }
 
-
+                    // save the initial XmlBuilder because it contains testcases already created, in order to speed up the report building
+                    JunitXmlBuilder initialXmlBuilder = ((RunnerBase)runner).XmlBuilder;
                     //create the runner according to type
                     runner = CreateRunner(_runType, false, failedTests);
 
@@ -310,10 +310,11 @@ namespace HpToolsLauncher
                         return;
                     }
 
+                    ((RunnerBase)runner).XmlBuilder = initialXmlBuilder; // reuse the populated initialXmlBuilder because it contains testcases already created, in order to speed up the report building
                     TestSuiteRunResults rerunResults = runner.Run();
 
                     results.AppendResults(rerunResults);
-                    RunTests(runner, resultsFilename, results);
+                    RunSummary(runner, resultsFilename, results);
                     Environment.Exit((int)_exitCode);
                 }
             }
@@ -758,14 +759,15 @@ namespace HpToolsLauncher
 
                     SummaryDataLogger summaryDataLogger = GetSummaryDataLogger();
                     List<ScriptRTSModel> scriptRTSSet = GetScriptRtsSet();
+                    string resultsFilename = _ciParams["resultsFilename"];
                     if (_ciParams.ContainsKey("fsUftRunMode"))
                     {
                         string uftRunMode = _ciParams["fsUftRunMode"];
-                        runner = new FileSystemTestsRunner(validTests, timeout, uftRunMode, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, scriptRTSSet, reportPath);
+                        runner = new FileSystemTestsRunner(validTests, timeout, uftRunMode, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, scriptRTSSet, reportPath, resultsFilename);
                     }
                     else
                     {
-                        runner = new FileSystemTestsRunner(validTests, timeout, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, scriptRTSSet, reportPath);
+                        runner = new FileSystemTestsRunner(validTests, timeout, pollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnectionInfo, mobileinfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, scriptRTSSet, reportPath, resultsFilename);
                     }
 
                     break;
@@ -862,23 +864,26 @@ namespace HpToolsLauncher
         /// <param name="runner"></param>
         /// <param name="resultsFile"></param>
         ///
-        private void RunTests(IAssetRunner runner, string resultsFile, TestSuiteRunResults results)
+        private void RunSummary(IAssetRunner runner, string resultsFile, TestSuiteRunResults results)
         {
             try
             {
-                if (_ciRun)
-                {
-                    _xmlBuilder = new JunitXmlBuilder();
-                    _xmlBuilder.XmlName = resultsFile;
-                }
-
                 if (results == null)
                 {
                     Environment.Exit((int)ExitCodeEnum.Failed);
                     return;
                 }
 
-                _xmlBuilder.CreateXmlFromRunResults(results);
+                if (_runType != TestStorageType.FileSystem) // for FileSystem the report is already generated inside FileSystemTestsRunner.Run()
+                {
+                    if (_ciRun)
+                    {
+                        _xmlBuilder = new JunitXmlBuilder();
+                        _xmlBuilder.XmlName = resultsFile;
+                    }
+
+                    _xmlBuilder.CreateXmlFromRunResults(results);
+                }
 
                 if (results.TestRuns.Count == 0)
                 {
@@ -985,7 +990,8 @@ namespace HpToolsLauncher
                     {
                         Environment.Exit((int)_exitCode);
                     }
-                } else
+                }
+                else
 				{
                     Environment.Exit((int)_exitCode);
                 }
@@ -999,7 +1005,7 @@ namespace HpToolsLauncher
                 catch (Exception ex)
                 {
                     ConsoleWriter.WriteLine(string.Format(Resources.LauncherRunnerDisposeError, ex.Message));
-                };
+                }
             }
         }
 

--- a/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
+++ b/HpToolsLauncher/Runners/FileSystemTestsRunner.cs
@@ -67,10 +67,8 @@ namespace HpToolsLauncher
         //saves runners for cleaning up at the end.
         private Dictionary<TestType, IFileSysTestRunner> _colRunnersForCleanup = new Dictionary<TestType, IFileSysTestRunner>();
 
-
         private McConnectionInfo _mcConnection;
         private string _mobileInfoForAllGuiTests;
-
 
 		#endregion
 
@@ -108,9 +106,10 @@ namespace HpToolsLauncher
                                     SummaryDataLogger summaryDataLogger,
                                     List<ScriptRTSModel> scriptRtsSet,
                                     string reportPath,
+                                    string xmlResultsFullFileName,
                                     bool useUftLicense = false)
 
-            : this(sources, timeout, controllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, scriptRtsSet, reportPath, useUftLicense)
+            : this(sources, timeout, controllerPollingInterval, perScenarioTimeOutMinutes, ignoreErrorStrings, jenkinsEnvVariables, mcConnection, mobileInfo, parallelRunnerEnvironments, displayController, analysisTemplate, summaryDataLogger, scriptRtsSet, reportPath, xmlResultsFullFileName, useUftLicense)
         {
             _uftRunMode = uftRunMode;
         }
@@ -147,13 +146,14 @@ namespace HpToolsLauncher
                                     SummaryDataLogger summaryDataLogger,
                                     List<ScriptRTSModel> scriptRtsSet,
                                     string reportPath,
+                                    string xmlResultsFullFileName,
                                     bool useUftLicense = false)
         {
             _jenkinsEnvVariables = jenkinsEnvVariables;
             //search if we have any testing tools installed
             if (!Helper.IsTestingToolsInstalled(TestStorageType.FileSystem))
             {
-                ConsoleWriter.WriteErrLine(string.Format(Resources.FileSystemTestsRunner_No_HP_testing_tool_is_installed_on, System.Environment.MachineName));
+                ConsoleWriter.WriteErrLine(string.Format(Resources.FileSystemTestsRunner_No_HP_testing_tool_is_installed_on, Environment.MachineName));
                 Environment.Exit((int)Launcher.ExitCodeEnum.Failed);
             }
 
@@ -176,6 +176,7 @@ namespace HpToolsLauncher
             _mobileInfoForAllGuiTests = mobileInfo;
 
             _parallelRunnerEnvironments = parallelRunnerEnvironments;
+            _xmlBuilder.XmlName = xmlResultsFullFileName;
 
             ConsoleWriter.WriteLine("UFT Mobile connection info is - " + _mcConnection.ToString());
 
@@ -293,6 +294,9 @@ namespace HpToolsLauncher
         {
             //create a new Run Results object
             TestSuiteRunResults activeRunDesc = new TestSuiteRunResults();
+            bool isNewTestSuite;
+            testsuite ts = _xmlBuilder.TestSuites.GetTestSuiteOrDefault(activeRunDesc.SuiteName, JunitXmlBuilder.ClassName, out isNewTestSuite);
+            ts.tests += _tests.Count;
 
             double totalTime = 0;
             try
@@ -307,16 +311,15 @@ namespace HpToolsLauncher
 
                 Dictionary<string, int> rerunList = createDictionary(_tests);
 
-                foreach (var test in _tests)
+                for (int x = 0; x < _tests.Count; x++)
                 {
+                    var test = _tests[x];
                     if (indexList[test.TestPath] == 0)
                     {
                         indexList[test.TestPath] = 1;
                     }
 
                     if (RunCancelled()) break;
-
-                    var testStart = DateTime.Now;
 
                     string errorReason = string.Empty;
                     TestRunResults runResult = null;
@@ -351,7 +354,7 @@ namespace HpToolsLauncher
                         {
                             if (string.IsNullOrEmpty(runResult.ErrorDesc))
                             {
-                                runResult.ErrorDesc = RunCancelled() ? HpToolsLauncher.Properties.Resources.ExceptionUserCancelled : HpToolsLauncher.Properties.Resources.ExceptionExternalProcess;
+                                runResult.ErrorDesc = RunCancelled() ? Resources.ExceptionUserCancelled : Resources.ExceptionExternalProcess;
                             }
                             runResult.ReportLocation = null;
                             runResult.TestState = TestState.Error;
@@ -368,8 +371,7 @@ namespace HpToolsLauncher
                         ConsoleWriter.WriteLine(string.Format(Resources.FsRunnerTestDone, runResult.TestState));
                     }
 
-                    UpdateCounters(runResult.TestState);
-                    var testTotalTime = (DateTime.Now - testStart).TotalSeconds;
+                    UpdateCounters(runResult.TestState, ts);
 
                     //create test folders
                     if (rerunList[test.TestPath] > 0)
@@ -386,9 +388,9 @@ namespace HpToolsLauncher
                     }
 
                     //update report folder
-                    String uftReportDir = Path.Combine(test.TestPath, "Report");
-                    String uftReportDirNew = Path.Combine(test.TestPath, "Report" + indexList[test.TestPath]);
-                    ConsoleWriter.WriteLine("uftReportDir is " + uftReportDirNew);
+                    string uftReportDir = Path.Combine(test.TestPath, "Report");
+                    string uftReportDirNew = Path.Combine(test.TestPath, string.Format("Report{0}", indexList[test.TestPath]));
+                    ConsoleWriter.WriteLine(string.Format("uftReportDir is {0}", uftReportDirNew));
                     try
                     {
                         if (Directory.Exists(uftReportDir))
@@ -401,12 +403,14 @@ namespace HpToolsLauncher
                             Directory.Move(uftReportDir, uftReportDirNew);
                         }
                     }
-                    catch(Exception e)
+                    catch(Exception)
                     {
                         System.Threading.Thread.Sleep(1000);
                         Directory.Move(uftReportDir, uftReportDirNew);
                     }
 
+                    // Create or update the xml report. This function is called after each test execution in order to have a report available in case of job interruption
+                    _xmlBuilder.CreateOrUpdatePartialXmlReport(ts, runResult, isNewTestSuite && x==0);
                     ConsoleWriter.WriteLine(DateTime.Now.ToString(Launcher.DateFormat) + " Test complete: " + runResult.TestPath + "\n-------------------------------------------------------------------------------------------------------");
                 }
 
@@ -597,18 +601,20 @@ namespace HpToolsLauncher
         /// sums errors and failed tests
         /// </summary>
         /// <param name="testState"></param>
-        private void UpdateCounters(TestState testState)
+        private void UpdateCounters(TestState testState, testsuite ts)
         {
             switch (testState)
             {
                 case TestState.Error:
-                    _errors += 1;
+                    _errors++;
+                    ts.errors++;
                     break;
                 case TestState.Failed:
-                    _fail += 1;
+                    _fail++;
+                    ts.failures++;
                     break;
                 case TestState.Warning:
-                    _warnings += 1;
+                    _warnings++;
                     break;
             }
         }

--- a/HpToolsLauncher/Runners/RunnerBase.cs
+++ b/HpToolsLauncher/Runners/RunnerBase.cs
@@ -32,16 +32,22 @@ namespace HpToolsLauncher
 {
     public class RunnerBase : IAssetRunner
     {
-
         public virtual void Dispose()
         {
         }
         protected bool _blnRunCancelled = false;
+        protected JunitXmlBuilder _xmlBuilder = new JunitXmlBuilder();
 
         public bool RunWasCancelled
         {
             get { return _blnRunCancelled; }
             set { _blnRunCancelled = value; }
+        }
+
+        public JunitXmlBuilder XmlBuilder
+        {
+            get { return _xmlBuilder; }
+            set { _xmlBuilder = value; }
         }
 
         public virtual TestSuiteRunResults Run()


### PR DESCRIPTION
DEF-735118 [Jenkins][ALM] All Test Sets are run if "\\" is used as path
US-740059 [Jenkins][FS Execution] Partial test results Reporting, for aborted Jenkins builds and unfinished tests execution