### PR TITLE
Replace deprecated usage with non-deprecated equivalent

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/actions/Webhooks.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/actions/Webhooks.java
@@ -47,7 +47,7 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;


### PR DESCRIPTION
Replaces a usage of the deprecated `org.apache.commons.httpclient.HttpStatus` with the non-deprecated `org.apache.http.HttpStatus` class that is used everywhere else that `HttpStatus` is needed in this code base.

CC @dorin7bogdan @plescaevelyn