### PR TITLE
JENKINS-68498 - JAXB error during job run with HPE ALI plugin on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
 		<dependency>
 			<groupId>com.microfocus.sv</groupId>
 			<artifactId>SVConfigurator</artifactId>
-			<version>5.5</version>
+			<version>5.8</version>
 			<exclusions>
 				<!-- Provided by Jenkins core -->
 				<exclusion>


### PR DESCRIPTION
This problem was reported in https://issues.jenkins.io/browse/JENKINS-68498

SV integration is failing on Java 11 with:
`java.lang.ClassNotFoundException: com.sun.xml.internal.bind.v2.ContextFactory`
because JAXB API is missing in Java 11

Above exception is caused by SVConfigurator 5.5, which relies on the JAXB libraries in the Java runtime. New version of SVConfigurator 5.8 was released to address this issue. This PR is just referencing new version of SVConfigurator 5.8

Fixing commit in SVConfigurator: https://github.com/MicroFocus/sv-configurator/commit/b99ddd98b41b8d29c7a1fd9f9617c607a3497395

Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [x] Proper pull request title - concise and clear for others.
- [x] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [x] Proper Jira ticket - Number, Link in pull request description.
- [x] The PR can is merged on your machine without any conflicts.
- [x] The PR can is built on your machine without any (new) warnings.
- [x] The PR passed sanity tests by you / QA / DevTest / Good Samaritan.
- [ ] Add unit tests with new features.
- [ ] If you added any dependency to the POM - Please update grount
