### PR TITLE
Fixing CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,26 +365,14 @@
 			<artifactId>apache-httpcomponents-client-4-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.jayway.jsonpath</groupId>
-			<artifactId>json-path</artifactId>
-			<version>2.7.0</version>
-			<exclusions>
-				<!-- Provided by Jenkins core -->
-				<exclusion>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-				</exclusion>
-				<!-- Provided by Jenkins core -->
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<!-- Provided by Jenkins core -->
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-jdk14</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>net.minidev</groupId>
+			<artifactId>json-smart</artifactId>
+			<version>2.5.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.ivy</groupId>
+			<artifactId>ivy</artifactId>
+			<version>2.5.2</version>
 		</dependency>
 		<!--workflow-aggregator-plugin : https://github.com/jenkinsci/workflow-aggregator-plugin
 		cloudbees doesn't support 2.6 therefore it is added manually -->
@@ -427,6 +415,12 @@
 		<dependency>
 			<groupId>org.jenkinsci.plugins</groupId>
 			<artifactId>pipeline-model-definition</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.ivy</groupId>
+					<artifactId>ivy</artifactId>
+				</exclusion>
+			</exclusions>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -511,7 +505,7 @@
 		<dependency>
 			<artifactId>maven-plugin</artifactId>
 			<groupId>org.jenkins-ci.main</groupId>
-			<version>3.15.1</version>
+			<version>3.19</version>
 		</dependency>
 		<dependency>
 			<artifactId>matrix-project</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -379,14 +379,17 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
+			<version>625.vd896b_f445a_f8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-api</artifactId>
+			<version>1144.v61c3180fa_03f</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-support</artifactId>
+			<version>813.vb_d7c3d2984a_0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -395,6 +398,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-job</artifactId>
+			<version>1145.v7f2433caa07f</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -426,14 +430,17 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>structs</artifactId>
+			<version>308.v852b473a2b8c</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>scm-api</artifactId>
+			<version>602.v6a_81757a_31d2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>script-security</artifactId>
+			<version>1158.v7c1b_73a_69a_08</version>
 			<scope>test</scope>
 		</dependency>
 		<!--workflow-aggregator-plugin-->
@@ -475,7 +482,59 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>junit</artifactId>
+			<version>1119.1121.vc43d0fc45561</version>
 
+			<exclusions>			
+				<exclusion>
+					<groupId>io.jenkins.plugins</groupId>
+					<artifactId>font-awesome-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.jenkins.plugins</groupId>
+					<artifactId>echarts-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.jenkins.plugins</groupId>
+					<artifactId>plugin-util-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.jenkins.plugins</groupId>
+					<artifactId>checks-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jenkins-ci.plugins</groupId>
+					<artifactId>display-url-api</artifactId>
+				</exclusion>
+			</exclusions> 
+		</dependency>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>font-awesome-api</artifactId>
+			<version>6.0.0-1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>echarts-api</artifactId>
+			<version>5.3.2-1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>plugin-util-api</artifactId>
+			<version>2.16.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>checks-api</artifactId>
+			<version>1.7.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>display-url-api</artifactId>
+			<version>2.3.6</version>
+		</dependency>
 		<!-- Octane jenkins plugins -->
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -475,12 +475,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>junit</artifactId>
-			<version>1119.1121.vc43d0fc45561</version>
-		</dependency>
-
 
 		<!-- Octane jenkins plugins -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -478,6 +478,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
+			<version>1119.1121.vc43d0fc45561</version>
 		</dependency>
 
 
@@ -555,7 +556,7 @@
 		<dependency>
 			<artifactId>token-macro</artifactId>
 			<groupId>org.jenkins-ci.plugins</groupId>
-			<version>267.vcdaea6462991</version> <!-- TODO use version from BOM when possible -->
+			<version>293.v283932a_0a_b_49</version> <!-- TODO use version from BOM when possible -->
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -567,6 +568,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
+			<version>414.vcc4c33714601</version>
 			<optional>true</optional>
 		</dependency>
 


### PR DESCRIPTION
CVE-2023-1370: Upgraded _net.minidev/json.smart_ to version 2.5.1 
CVE-2023-1370: Upgraded _net.minidev/json.smart_ to version 2.5.1 
CVE-2022-29599: Upgraded the _maven-plugin/org.jenkins-ci.main_ to version 3.19 which contains a safe version (3.3.4) of the _maven-shared-utils_ library 
CVE-2022-37865 & CVE-2022-37866: Removed unneeded library(_com.jayway.jsonpath/json-path_) and included the safe 2.5.2 version of _org.apache.ivy/ivy_
