### PR TITLE
externalRunId set incorrectly 

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
@@ -495,6 +495,7 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
         externalURL = "";
         description = "";
         uftResultFilePath = "";
+        externalRunId = "";
         moduleName = moduleNameFromFile;
         uftResultData = null;
     }


### PR DESCRIPTION
After executing a test that included parameters, the External ID for subsequent tests was incorrectly set. Making the tests appear as skipped in octane. 
The fix for this was to reset the value of the externalRunId to an empty string.