### PR TITLE
US-1903941, D-1898430, D-1898414, US-1898431

### DIFF
--- a/HpToolsLauncher/Launcher.cs
+++ b/HpToolsLauncher/Launcher.cs
@@ -248,8 +248,6 @@ namespace HpToolsLauncher
 
             switch (_runType)
             {
-                case TestStorageType.AlmLabManagement:
-
                 case TestStorageType.Alm:
                 { 
                     //check that all required parameters exist

--- a/HpToolsLauncher/Program.cs
+++ b/HpToolsLauncher/Program.cs
@@ -46,7 +46,6 @@ namespace HpToolsLauncher
     public enum TestStorageType
     {
         Alm,
-        AlmLabManagement,
         FileSystem,
         LoadRunner,
         MBT,

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -890,17 +890,7 @@ namespace HpToolsLauncher
 
             try
             {
-                //check test storage type
-                if (testStorageType.Equals(TestStorageType.AlmLabManagement))
-                {
-                    tsFolder = (ITestSetFolder)tsTreeManager.NodeByPath["Root"];
-                    GetTestSetById(tsFolder, Convert.ToInt32(tsName), ref testSuiteName);
-                }
-                else
-                {
-                    tsFolder = (ITestSetFolder)tsTreeManager.get_NodeByPath(tsPath);
-                }
-
+                tsFolder = (ITestSetFolder)tsTreeManager.get_NodeByPath(tsPath);
                 isTestPath = false;
             }
             catch (COMException ex)
@@ -1548,10 +1538,6 @@ namespace HpToolsLauncher
             ITSTest currentTest = null;
             string abortFilename = string.Format(@"{0}\stop{1}.txt", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), Launcher.UniqueTimeStamp);
 
-            if (Storage == TestStorageType.AlmLabManagement)
-            {
-                Timeout *= 60;
-            }
             //update run result description
             UpdateTestsResultsDescription(ref activeTestDesc, runDesc, scheduler, targetTestSet, currentTestSetInstances, Timeout, executionStatus, swForTimeout, ref prevTest, ref currentTest, abortFilename);
 

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -1410,7 +1410,7 @@ namespace HpToolsLauncher
             }
 
             ConsoleWriter.WriteLine(Resources.AlmRunnerStartingExecution);
-            ConsoleWriter.WriteLine(string.Format("Index: {0}, ID: {1}, Full path: \"{2}\"", testIdx, targetTestSet.ID, testSetItem));
+            ConsoleWriter.WriteLine(string.Format("TestSet {0}: ID = {1}, Path = \"{2}\"", testIdx, targetTestSet.ID, testSetItem));
             ConsoleWriter.WriteLine(Resources.SingleSeperator);
 
             //start execution

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -1295,6 +1295,15 @@ namespace HpToolsLauncher
                 return null;
             }
 
+            if (TestSetsRunOrderByCriteria == "name" || TestSetsRunOrderByCriteria == "")
+            {
+                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by name.");
+            }
+            else
+            {
+                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by ID.");
+            }
+
             // we start the timer, it is important for the timeout
             Stopwatch swForTimeout = Stopwatch.StartNew();
 
@@ -1335,7 +1344,7 @@ namespace HpToolsLauncher
                     }
                 }
 
-                TestSuiteRunResults runResults = RunTestSet(testSetDir, tsName, inlineTestParams, swForTimeout, idx);
+                TestSuiteRunResults runResults = RunTestSet(testSetDir, tsName, inlineTestParams, swForTimeout, idx, testSetItem);
                 if (runResults != null)
                     activeRunDescription.AppendResults(runResults);
 
@@ -1357,7 +1366,7 @@ namespace HpToolsLauncher
         /// <param name="swForTimeout"></param>
         /// <param name="testIdx"></param>
         /// <returns></returns>
-        public TestSuiteRunResults RunTestSet(string tsFolderName, string tsName, string inlineTestParams, Stopwatch swForTimeout, int testIdx)
+        public TestSuiteRunResults RunTestSet(string tsFolderName, string tsName, string inlineTestParams, Stopwatch swForTimeout, int testIdx, string testSetItem)
         {
             string testSuiteName = tsName.Trim();
             ITestSetFolder tsFolder = null;
@@ -1411,7 +1420,13 @@ namespace HpToolsLauncher
             }
 
             ConsoleWriter.WriteLine(Resources.AlmRunnerStartingExecution);
-            ConsoleWriter.WriteLine(string.Format(Resources.AlmRunnerDisplayTest, testSuiteName, targetTestSet.ID));
+            ConsoleWriter.WriteLine(Resources.SingleSeperator);
+            ConsoleWriter.WriteLine("Test Set Details:");
+            ConsoleWriter.WriteLine(string.Format("  - ID: {0}", targetTestSet.ID));
+            ConsoleWriter.WriteLine(string.Format("  - Name: {0}", testSuiteName));
+            ConsoleWriter.WriteLine(string.Format("  - Path: {0}", testSetItem));
+            ConsoleWriter.WriteLine(string.Format("  - Index: {0}", testIdx));
+            ConsoleWriter.WriteLine(Resources.SingleSeperator);
 
             //start execution
             ITSScheduler scheduler = null;

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -790,7 +790,6 @@ namespace HpToolsLauncher
             }
         }
 
-
         /// <summary>
         /// Recursively find all test sets in the QC directory tree, starting from a given folder
         /// </summary>

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -80,6 +80,10 @@ namespace HpToolsLauncher
         private const string _EXE = ".exe";
         private const string SOFTWARE_WOW6432_CLASSES_CLSID_0 = @"Software\WOW6432Node\Classes\CLSID\{0}";
         private const string FILE_ISNT_REGISTERED = @"{0} is not registered in HKLM\{1}.";
+        private const string ID = "id";
+        private const string BY_ID = "ID";
+        private const string BY_NAME = "Name";
+        private const string ORDERBY_MESSAGE = "Test sets will be executed in ascending order by";
 
         public ITDConnection13 TdConnection
         {
@@ -320,14 +324,6 @@ namespace HpToolsLauncher
             }
         }
 
-        /// <summary>
-        /// destructor - ensures dispose of connection
-        /// </summary>
-        ~AlmTestSetsRunner()
-        {
-            Dispose(false);
-        }
-
         private class PathSorter
         {
             public static List<string> SortPaths(List<TestSetItem> items, string almTestSetsRunOrderByCriteria)
@@ -354,16 +350,6 @@ namespace HpToolsLauncher
                 public string Name
                 {
                     get { return _name; }
-                }
-
-                public Dictionary<string, Node> Children
-                {
-                    get { return _children; }
-                }
-
-                public List<TestSetItem> Leaves
-                {
-                    get { return _leaves; }
                 }
 
                 public Node(string name)
@@ -402,9 +388,9 @@ namespace HpToolsLauncher
                     }
 
                     // 2) Sort test sets either by Name or by ID
-                    IEnumerable<TestSetItem> sortedLeaves = (almTestSetsRunOrderByCriteria == "name" || almTestSetsRunOrderByCriteria == "")
-                        ? _leaves.OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
-                        : _leaves.OrderBy(l => l.ID);
+                    IEnumerable<TestSetItem> sortedLeaves = almTestSetsRunOrderByCriteria == ID ?
+                        _leaves.OrderBy(l => l.ID) :
+                        _leaves.OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase);
 
                     foreach (var leaf in sortedLeaves)
                     {
@@ -1073,41 +1059,6 @@ namespace HpToolsLauncher
         }
 
         /// <summary>
-        /// Search test set in QC by the given ID
-        /// </summary>
-        /// <param name="tsFolder"></param>
-        /// <param name="testSetId"></param>
-        /// <param name="testSuiteName"></param>
-        /// <returns>the test set identified by the given id or empty string in case the test set was not found</returns>
-        private string GetTestSetById(ITestSetFolder tsFolder, int testSetId, ref string testSuiteName)
-        {
-            List children = tsFolder.FindChildren(string.Empty);
-            List testSets = tsFolder.FindTestSets(string.Empty);
-
-            if (testSets != null)
-            {
-                foreach (ITestSet childSet in testSets)
-                {
-                    if (childSet.ID != testSetId) continue;
-                    string tsPath = childSet.TestSetFolder.Path;
-                    tsPath = tsPath.Substring(5).Trim(BACK_SLASH);
-                    string tsFullPath = tsPath + BackSlash_ + childSet.Name;
-                    testSuiteName = childSet.Name;
-                    return tsFullPath.Trim();
-                }
-            }
-
-            if (children != null)
-            {
-                foreach (ITestSetFolder childFolder in children)
-                {
-                    GetAllTestSetsFromDirTree(childFolder);
-                }
-            }
-            return string.Empty;
-        }
-
-        /// <summary>
         /// Gets test index given it's name
         /// </summary>
         /// <param name="strName"></param>
@@ -1285,14 +1236,7 @@ namespace HpToolsLauncher
                 return null;
             }
 
-            if (TestSetsRunOrderByCriteria == "id")
-            {
-                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by ID.");
-            }
-            else
-            {
-                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by name.");
-            }
+            ConsoleWriter.WriteLine(string.Format(ORDERBY_MESSAGE, TestSetsRunOrderByCriteria == ID ? BY_ID : BY_NAME));
 
             // we start the timer, it is important for the timeout
             Stopwatch swForTimeout = Stopwatch.StartNew();
@@ -2255,7 +2199,7 @@ namespace HpToolsLauncher
             try
             {
                 var sf = pTest.StepFactory as StepFactory;
-                ; if (sf == null)
+                if (sf == null)
                     return string.Empty;
 
                 var stepList = sf.NewList(string.Empty) as IList;
@@ -2341,12 +2285,6 @@ namespace HpToolsLauncher
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-    }
-
-    public class QCFailure
-    {
-        public string Name { get; set; }
-        public string Desc { get; set; }
     }
 
     public enum QcRunMode

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -1295,13 +1295,13 @@ namespace HpToolsLauncher
                 return null;
             }
 
-            if (TestSetsRunOrderByCriteria == "name" || TestSetsRunOrderByCriteria == "")
+            if (TestSetsRunOrderByCriteria == "id")
             {
-                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by name.");
+                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by ID.");
             }
             else
             {
-                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by ID.");
+                ConsoleWriter.WriteLine("Test sets will be executed in ascending order by name.");
             }
 
             // we start the timer, it is important for the timeout
@@ -1420,12 +1420,7 @@ namespace HpToolsLauncher
             }
 
             ConsoleWriter.WriteLine(Resources.AlmRunnerStartingExecution);
-            ConsoleWriter.WriteLine(Resources.SingleSeperator);
-            ConsoleWriter.WriteLine("Test Set Details:");
-            ConsoleWriter.WriteLine(string.Format("  - ID: {0}", targetTestSet.ID));
-            ConsoleWriter.WriteLine(string.Format("  - Name: {0}", testSuiteName));
-            ConsoleWriter.WriteLine(string.Format("  - Path: {0}", testSetItem));
-            ConsoleWriter.WriteLine(string.Format("  - Index: {0}", testIdx));
+            ConsoleWriter.WriteLine(string.Format("Index: {0}, ID: {1}, Full path: \"{2}\"", testIdx, targetTestSet.ID, testSetItem));
             ConsoleWriter.WriteLine(Resources.SingleSeperator);
 
             //start execution

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -395,7 +395,7 @@ namespace HpToolsLauncher
                 public void SortAndFlatten(List<string> result, string currentPath, string almTestSetsRunOrderByCriteria)
                 {
                     // 1) Sort subfolders by folder name
-                    foreach (var child in _children.Values.OrderBy(n => n.Name, StringComparer.Ordinal))
+                    foreach (var child in _children.Values.OrderBy(n => n.Name))
                     {
                         string childPath = string.IsNullOrEmpty(currentPath) ? child.Name: currentPath + BackSlash_ + child.Name;
                         child.SortAndFlatten(result, childPath, almTestSetsRunOrderByCriteria);
@@ -403,7 +403,7 @@ namespace HpToolsLauncher
 
                     // 2) Sort test sets either by Name or by ID
                     IEnumerable<TestSetItem> sortedLeaves = (almTestSetsRunOrderByCriteria == "name" || almTestSetsRunOrderByCriteria == "")
-                        ? _leaves.OrderBy(l => l.Name)
+                        ? _leaves.OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
                         : _leaves.OrderBy(l => l.ID);
 
                     foreach (var leaf in sortedLeaves)

--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -80,10 +80,9 @@ namespace HpToolsLauncher
         private const string _EXE = ".exe";
         private const string SOFTWARE_WOW6432_CLASSES_CLSID_0 = @"Software\WOW6432Node\Classes\CLSID\{0}";
         private const string FILE_ISNT_REGISTERED = @"{0} is not registered in HKLM\{1}.";
-        private const string ID = "id";
-        private const string BY_ID = "ID";
-        private const string BY_NAME = "Name";
-        private const string ORDERBY_MESSAGE = "Test sets will be executed in ascending order by";
+        private const string ID = "ID";
+        private const string NAME = "Name";
+        private const string ORDERBY_MESSAGE = "Test sets will be executed in ascending order by {0}.";
 
         public ITDConnection13 TdConnection
         {
@@ -388,7 +387,7 @@ namespace HpToolsLauncher
                     }
 
                     // 2) Sort test sets either by Name or by ID
-                    IEnumerable<TestSetItem> sortedLeaves = almTestSetsRunOrderByCriteria == ID ?
+                    IEnumerable<TestSetItem> sortedLeaves = almTestSetsRunOrderByCriteria == ID.ToLower() ?
                         _leaves.OrderBy(l => l.ID) :
                         _leaves.OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase);
 
@@ -1236,7 +1235,7 @@ namespace HpToolsLauncher
                 return null;
             }
 
-            ConsoleWriter.WriteLine(string.Format(ORDERBY_MESSAGE, TestSetsRunOrderByCriteria == ID ? BY_ID : BY_NAME));
+            ConsoleWriter.WriteLine(string.Format(ORDERBY_MESSAGE, TestSetsRunOrderByCriteria == ID.ToLower() ? ID : NAME));
 
             // we start the timer, it is important for the timeout
             Stopwatch swForTimeout = Stopwatch.StartNew();

--- a/src/main/java/com/microfocus/application/automation/tools/model/RunFromAlmModel.java
+++ b/src/main/java/com/microfocus/application/automation/tools/model/RunFromAlmModel.java
@@ -240,7 +240,7 @@ public class RunFromAlmModel extends AbstractDescribableImpl<RunFromAlmModel> {
 
         props.put("almRunMode", almRunMode);
 
-        if (almTestSetsRunOrderByCriteria != null && !almTestSetsRunOrderByCriteria.isBlank()) {
+        if (StringUtils.isNotBlank(almTestSetsRunOrderByCriteria)) {
             props.put("almTestSetsRunOrderByCriteria", almTestSetsRunOrderByCriteria);
         }
 

--- a/src/main/java/com/microfocus/application/automation/tools/model/RunFromAlmModel.java
+++ b/src/main/java/com/microfocus/application/automation/tools/model/RunFromAlmModel.java
@@ -240,7 +240,7 @@ public class RunFromAlmModel extends AbstractDescribableImpl<RunFromAlmModel> {
 
         props.put("almRunMode", almRunMode);
 
-        if (!almTestSetsRunOrderByCriteria.isBlank()) {
+        if (almTestSetsRunOrderByCriteria != null && !almTestSetsRunOrderByCriteria.isBlank()) {
             props.put("almTestSetsRunOrderByCriteria", almTestSetsRunOrderByCriteria);
         }
 


### PR DESCRIPTION
1903941 - Continuation of [Jenkins][ALM] Possible option to give test script sequence
https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=1903941

1898430 - [Jenkins][ALM] Test Sets Paths and Order By Criteria are not Displayed when Running Tests
https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=1898430

1898414 - [Jenkins][ALM] Sorting Test Set Execution by Name is Case Insensitive
https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=1898414

1898431 - [Jenkins][ALM] Cleanup Old Code Related to Lab management
https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=1898431