### PR TITLE
D830050 - Fix Jenkins UFT API report link from GUI test

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/results/RunResultRecorder.java
@@ -330,21 +330,16 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	private void zipSelectedFolders(FilePath base, List<FilePath> foldersToInclude, FilePath destZipFile, TaskListener listener) throws IOException, InterruptedException {
+	private void zipSelectedFolders(FilePath base, List<FilePath> foldersToInclude, FilePath destZipFile) throws IOException, InterruptedException {
 		try (OutputStream fos = destZipFile.write(); ZipOutputStream zos = new ZipOutputStream(fos)) {
-			final String basePrefix = base.getRemote().replace('\\', '/') + "/";
+			String basePrefix = base.getRemote().replace('\\', '/');
+			if (!basePrefix.endsWith("/")) {
+				basePrefix += "/";
+			}
 			for (FilePath folder : foldersToInclude) {
-				if (!folder.exists()) {
-					continue;
-				}
 				for (FilePath file : folder.list("**/*")) {
-					if (file.isDirectory()) {
-						continue;
-					}
-					String fullPath = file.getRemote().replace('\\', '/');
-					String entryName = fullPath.substring(basePrefix.length());
-					ZipEntry ze = new ZipEntry(entryName);
-					zos.putNextEntry(ze);
+					String entryName = file.getRemote().replace('\\', '/').substring(basePrefix.length());
+					zos.putNextEntry(new ZipEntry(entryName));
 					try (InputStream in = file.read()) {
 						in.transferTo(zos);
 					}
@@ -605,18 +600,18 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 								}
 
 								List<FilePath> foldersToInclude = new ArrayList<>();
+								foldersToInclude.add(reportFolder);
 								for (String dir : reportMetaData.getStResFolders()) {
 									FilePath stResDirs = new FilePath(baseFolder, dir);
 									if (stResDirs.exists()) {
 										foldersToInclude.add(stResDirs);
 									}
 								}
-								foldersToInclude.add(reportFolder);
 								String zipFileName = getUniqueZipFileNameInFolder(zipFileNames, (StringUtils.isBlank(nodeName) ? "" : nodeName + "_") + testFolder.getName(), "UFT");
 								zipFileNames.add(zipFileName);
 								FilePath archivedFiles = new FilePath(new FilePath(artifactsDir), zipFileName);
 
-								zipSelectedFolders(baseFolder, foldersToInclude, archivedFiles, listener);
+								zipSelectedFolders(baseFolder, foldersToInclude, archivedFiles);
 
 								// add to Report list
 								String zipFileUrlName = "artifact/" + zipFileName;

--- a/src/main/java/com/microfocus/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/results/RunResultRecorder.java
@@ -91,6 +91,8 @@ import java.io.*;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static com.microfocus.application.automation.tools.results.projectparser.performance.XmlParserUtil.getNode;
 import static com.microfocus.application.automation.tools.results.projectparser.performance.XmlParserUtil.getNodeAttr;
@@ -316,6 +318,40 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 	private boolean isParallelRunnerReportPath(FilePath reportPath) throws IOException, InterruptedException {
 		FilePath parallelRunnerResultsFile = new FilePath(reportPath, PARALLEL_RESULT_FILE);
 		return parallelRunnerResultsFile.exists();
+	}
+
+	/**
+	 * Helper method that includes inside an archive all the necessary folders.
+	 *
+	 * @param base: base is the parent folder that contains Report/ and StRes*
+	 * @param foldersToInclude
+	 * @param destZipFile
+	 * @param listener
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private void zipSelectedFolders(FilePath base, List<FilePath> foldersToInclude, FilePath destZipFile, TaskListener listener) throws IOException, InterruptedException {
+		try (OutputStream fos = destZipFile.write(); ZipOutputStream zos = new ZipOutputStream(fos)) {
+			final String basePrefix = base.getRemote().replace('\\', '/') + "/";
+			for (FilePath folder : foldersToInclude) {
+				if (!folder.exists()) {
+					continue;
+				}
+				for (FilePath file : folder.list("**/*")) {
+					if (file.isDirectory()) {
+						continue;
+					}
+					String fullPath = file.getRemote().replace('\\', '/');
+					String entryName = fullPath.substring(basePrefix.length());
+					ZipEntry ze = new ZipEntry(entryName);
+					zos.putNextEntry(ze);
+					try (InputStream in = file.read()) {
+						in.transferTo(zos);
+					}
+					zos.closeEntry();
+				}
+			}
+		}
 	}
 
 	/**
@@ -562,25 +598,25 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 						if (archiveTestResult) {
 							if (reportFolder.exists()) {
 								FilePath testFolder = new FilePath(channel, testFolderPath);
-								String zipFileName = getUniqueZipFileNameInFolder(zipFileNames, (StringUtils.isBlank(nodeName) ? "" : nodeName + "_") + testFolder.getName(), "UFT");
-								zipFileNames.add(zipFileName);
-								try (ByteArrayOutputStream outStr = new ByteArrayOutputStream()) {
+								// get the parent of the report folder
+								FilePath baseFolder = reportFolder.getParent();
+								if (baseFolder == null) {
+									baseFolder = reportFolder;
+								}
 
-									// don't use FileFilter for zip, or it will cause bug when files are on slave
-									reportFolder.zip(outStr);
-
-									/*
-									 * I did't use copyRecursiveTo or copyFrom due to bug in
-									 * jekins:https://issues.jenkins-ci.org/browse /JENKINS-9189 //(which is
-									 * cleaimed to have been fixed, but not. So I zip the folder to stream and copy
-									 * it to the master.
-									 */
-
-									try (InputStream instr = new ByteArrayInputStream(outStr.toByteArray())) {
-										FilePath archivedFile = new FilePath(new FilePath(artifactsDir), zipFileName);
-										archivedFile.copyFrom(instr);
+								List<FilePath> foldersToInclude = new ArrayList<>();
+								for (String dir : reportMetaData.getStResFolders()) {
+									FilePath stResDirs = new FilePath(baseFolder, dir);
+									if (stResDirs.exists()) {
+										foldersToInclude.add(stResDirs);
 									}
 								}
+								foldersToInclude.add(reportFolder);
+								String zipFileName = getUniqueZipFileNameInFolder(zipFileNames, (StringUtils.isBlank(nodeName) ? "" : nodeName + "_") + testFolder.getName(), "UFT");
+								zipFileNames.add(zipFileName);
+								FilePath archivedFiles = new FilePath(new FilePath(artifactsDir), zipFileName);
+
+								zipSelectedFolders(baseFolder, foldersToInclude, archivedFiles, listener);
 
 								// add to Report list
 								String zipFileUrlName = "artifact/" + zipFileName;


### PR DESCRIPTION
D830050 - [Jenkins] API Tests Reports' links called from a GUI Test are not correct from the zipped archived Report from Jenkins
https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=830050

Now StRes1, StRes2, ..., StResN reports form API tests, will be included alongside the GUI test report, This was necessary for link to work.