### PR TITLE
D924005 mobile parallel device only fixes

### DIFF
--- a/src/main/webapp/configure.js
+++ b/src/main/webapp/configure.js
@@ -267,7 +267,7 @@ async function loadMobileInfo(a, b, o, err) {
                 tenantId = map["TENANT_ID_COOKIE"];
             }
             if(map.hasOwnProperty("isSaaS")) {
-                isSaaS = map["isSaaS"];
+                isSaaS = (map["isSaaS"] === "true");
             }
 
             if (jobId == null) {

--- a/src/main/webapp/configure.js
+++ b/src/main/webapp/configure.js
@@ -267,7 +267,7 @@ async function loadMobileInfo(a, b, o, err) {
                 tenantId = map["TENANT_ID_COOKIE"];
             }
             if(map.hasOwnProperty("isSaaS")) {
-                isSaaS = (map["isSaaS"] === "true");
+                isSaaS = map.isSaaS === "true" || map.isSaaS === true;
             }
 
             if (jobId == null) {

--- a/src/main/webapp/parallelRunnerEnvironment.js
+++ b/src/main/webapp/parallelRunnerEnvironment.js
@@ -618,6 +618,28 @@ function setViewVisibility(panel) {
 		updateFsView(panel, chkParallelRunner);
 	}, false);
 }
+
+/**
+ * Enforces mutual exclusivity between Parallel Runner and mobile/cloud execution.
+ * When parallel is enabled, mobile and cloud options are unchecked and disabled; otherwise they are re-enabled.
+ * @param panel - the current build step container
+ * @param isParallelRun - a flag that reflects the state of the Parallel run checkbox
+ */
+function enforceParallelConstraints(panel, isParallelRun) {
+	const mobile = panel.querySelector('input[name="useMobileDevice"]');
+	const cloud = panel.querySelector('input[name="cloudBrowserModel"]');
+
+	[mobile, cloud].forEach(function (checkBox) {
+		// If parallel is ON => turn OFF children + disable them
+		if (isParallelRun) {
+			checkBox.checked = false;
+		}
+		checkBox.disabled = isParallelRun;
+		// Let Jenkins optionalBlock / listeners react
+		checkBox.dispatchEvent(new Event("change", { bubbles: true }));
+	});
+}
+
 function updateFsView(panel, chkParallelRunner) {
 	const isParallelRun = chkParallelRunner.checked;
 	RunFromFileSystemEnv.setFsTestsVisibility(panel, !isParallelRun);
@@ -625,6 +647,8 @@ function updateFsView(panel, chkParallelRunner) {
 	RunFromFileSystemEnv.setParamsVisibility(panel, !isParallelRun);
 	//this panel should be automatically shown/hidden, so comment-out it for now to see if all works fine
 	//ParallelRunnerEnv.setEnvironmentsVisibility(panel, isParallelRun);
+	// enforce disabling mobile + cloud when parallel is enabled
+	enforceParallelConstraints(panel, isParallelRun);
 }
 function setupFsTask(hasConfigPermission) {
 	let divMain = null;

--- a/src/main/webapp/parallelRunnerEnvironment.js
+++ b/src/main/webapp/parallelRunnerEnvironment.js
@@ -345,7 +345,7 @@ Utils.loadMC = function(a, b, prEnv){
 				tenantId = map["TENANT_ID_COOKIE"];
 			}
 			if(map.hasOwnProperty("isSaaS")) {
-				isSaaS = (map["isSaaS"] === "true");
+				isSaaS = map.isSaaS === "true" || map.isSaaS === true;
 			}
 
 			// var jobId = response.responseObject();
@@ -608,6 +608,24 @@ RunFromFileSystemEnv.setParamsVisibility = function(panel, visible) {
 	this.setInputVisibility(panel, "areParametersEnabled", visible);
 };
 
+RunFromFileSystemEnv._cbStates = new WeakMap();
+
+RunFromFileSystemEnv.enforceParallelConstraints = function(panel, isParallelRun) {
+	const checkboxes = panel.querySelectorAll("input[name='useMobileDevice'], input[name='cloudBrowserModel']");
+	checkboxes.forEach(checkbox => {
+		if (isParallelRun) {
+			RunFromFileSystemEnv._cbStates.set(checkbox, checkbox.checked);
+			if (checkbox.checked === true)
+				checkbox.click(); // to close it
+			checkbox.disabled = true;
+		} else {
+			checkbox.disabled = false;
+			if (RunFromFileSystemEnv._cbStates.get(checkbox) === true)
+				checkbox.click(); // to reopen it.
+		}
+	});
+};
+
 /**
  * Hide/Show the corresponding controls based on the parallel runner checkBox state.
  */
@@ -619,27 +637,6 @@ function setViewVisibility(panel) {
 	}, false);
 }
 
-/**
- * Enforces mutual exclusivity between Parallel Runner and mobile/cloud execution.
- * When parallel is enabled, mobile and cloud options are unchecked and disabled; otherwise they are re-enabled.
- * @param panel - the current build step container
- * @param isParallelRun - a flag that reflects the state of the Parallel run checkbox
- */
-function enforceParallelConstraints(panel, isParallelRun) {
-	const mobile = panel.querySelector('input[name="useMobileDevice"]');
-	const cloud = panel.querySelector('input[name="cloudBrowserModel"]');
-
-	[mobile, cloud].forEach(function (checkBox) {
-		// If parallel is ON => turn OFF children + disable them
-		if (isParallelRun) {
-			checkBox.checked = false;
-		}
-		checkBox.disabled = isParallelRun;
-		// Let Jenkins optionalBlock / listeners react
-		checkBox.dispatchEvent(new Event("change", { bubbles: true }));
-	});
-}
-
 function updateFsView(panel, chkParallelRunner) {
 	const isParallelRun = chkParallelRunner.checked;
 	RunFromFileSystemEnv.setFsTestsVisibility(panel, !isParallelRun);
@@ -647,9 +644,9 @@ function updateFsView(panel, chkParallelRunner) {
 	RunFromFileSystemEnv.setParamsVisibility(panel, !isParallelRun);
 	//this panel should be automatically shown/hidden, so comment-out it for now to see if all works fine
 	//ParallelRunnerEnv.setEnvironmentsVisibility(panel, isParallelRun);
-	// enforce disabling mobile + cloud when parallel is enabled
-	enforceParallelConstraints(panel, isParallelRun);
+	RunFromFileSystemEnv.enforceParallelConstraints(panel, isParallelRun);
 }
+
 function setupFsTask(hasConfigPermission) {
 	let divMain = null;
 	if (document.location.href.indexOf("pipeline-syntax")>0) { // we are on pipeline-syntax page, where runFromFileBuilder step can be selected only once

--- a/src/main/webapp/parallelRunnerEnvironment.js
+++ b/src/main/webapp/parallelRunnerEnvironment.js
@@ -345,7 +345,7 @@ Utils.loadMC = function(a, b, prEnv){
 				tenantId = map["TENANT_ID_COOKIE"];
 			}
 			if(map.hasOwnProperty("isSaaS")) {
-				isSaaS = map["isSaaS"];
+				isSaaS = (map["isSaaS"] === "true");
 			}
 
 			// var jobId = response.responseObject();


### PR DESCRIPTION
URL: https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=924005
This defect was somehow solved before. But some fixes were made:
1. When parallel running is enabled the other controls for digital lab and cloud running were disabled, enforcing the user to choose only one.
2. The flag isSaaS was not correctly parsed to boolean, inside configure.js file. This led to a small bug that was unobserved until now.