### PR TITLE
D1952286 - Sender email address for the ALM execution report should not be hardcoded

### DIFF
--- a/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
+++ b/HpToolsLauncher/Runners/AlmTestSetsRunner.cs
@@ -84,6 +84,7 @@ namespace HpToolsLauncher
         private const string ID = "ID";
         private const string NAME = "Name";
         private const string ORDERBY_MESSAGE = "Test sets will be executed in ascending order by {0}.";
+        private const string EXECUTION_EVENT_NOTIFICATION = "Execution Event Notification";
         private readonly string _emailSummaryReceivers;
 
         public ITDConnection13 TdConnection
@@ -1313,7 +1314,7 @@ namespace HpToolsLauncher
                 ++idx;
             }
 
-            if (testSetResults.Count > 0)
+            if (testSetResults.Count > 0 && !_emailSummaryReceivers.IsNullOrWhiteSpace())
             {
                 ReportContext reportContext = new ReportContext
                 {
@@ -1326,7 +1327,7 @@ namespace HpToolsLauncher
                 
                 AlmHtmlReportBuilder htmlBuilder = new AlmHtmlReportBuilder();
                 string htmlReportPage = htmlBuilder.BuildReport(reportContext);
-                _tdConnection.SendMail(_emailSummaryReceivers, "alm-no-reply@opentext.com", "ALM Test Report", htmlReportPage);
+                _tdConnection.SendMail(SendTo: _emailSummaryReceivers, Subject: EXECUTION_EVENT_NOTIFICATION, Message: htmlReportPage);
             }
             return activeRunDescription;    
         }

--- a/src/main/java/com/microfocus/application/automation/tools/run/RunFromAlmBuilder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/run/RunFromAlmBuilder.java
@@ -568,6 +568,13 @@ public class RunFromAlmBuilder extends Builder implements SimpleBuildStep {
             return m;
         }
 
+        public FormValidation doCheckAlmEmailSummaryReceivers(@QueryParameter String value) {
+            if (value == null || value.trim().isEmpty()) {
+                return FormValidation.error("At least one receiver email is required.");
+            }
+            return FormValidation.ok();
+        }
+
         public FormValidation doCheckAlmTimeout(@QueryParameter String value) {
 
             if (StringUtils.isEmpty(value)) {


### PR DESCRIPTION
Task: https://internal.almoctane.com/ui/entity-navigation?p=45001/6001&entityType=work_item&id=1952286

This defect was raised due to my human error of not spotting the sender email address to be the one set inside ALM Site Administration.

**Short Story:**
At the first glance, any attempt to read the data from the server was returning empty strings, therefore when using the `SendEmail` method exposed by the OTA API I considered hardcoding the field responsible for the "From" email header.  Not having any clue about what to write there, I wrote a fictional email address: "_alm-no-reply@opentext.com_". This was not a professional move.
My teammates suggested me to create also a new textbox for the Jenkins UI, so that the user can specify the sender's email address so that the address that I hardcoded previously will not be used. So, I implemented that, adding a new UI feature that alerts the user when a field is empty and so on (see the defect above, linked by the provided URL).
Then the QA came and after a careful analysis, the senser was always read from the ALM Site Administration SMTP configuration, regardless the hardcoded email address or the one mentioned inside the supplementary textbox added lately. So, the problem was never a problem.

Thus, this pull request is meant to fix my mistakes and to clarify this situation. The release is ready! But with this occasion I added the UI indicators when the receivers textarea is empty and some logic enhancements in the C# part.

God bless!