### PR TITLE
Defect #3121389: Fix missing common_hash publication for Pipeline (WorkflowRun) finish events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
         <maven.exec.skip>false</maven.exec.skip>
         <jenkins-test-harness.version>2444.v82e008e25040
         </jenkins-test-harness.version> <!-- TODO newer versions than 2.55 require debugging an issue with open file handles -->
+        <java.level>21</java.level>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
 
 		<!-- The ending year for copyright information -->
 		<copyright.end.year>2025</copyright.end.year>

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/AbstractBuildListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/AbstractBuildListenerOctaneImpl.java
@@ -160,11 +160,7 @@ public final class AbstractBuildListenerOctaneImpl extends RunListener<AbstractB
 			if (scmProcessor != null) {
 				logger.debug("SCMProcessor found: {}, calling getCommonOriginRevision", scmProcessor.getClass().getName());
 				commonOriginRevision = scmProcessor.getCommonOriginRevision(build);
-				if (commonOriginRevision != null) {
-					logger.debug("Common origin revision calculated - branch: {}, revision: {}", commonOriginRevision.branch, commonOriginRevision.revision);
-				} else {
-					logger.warn("SCMProcessor returned null for common origin revision");
-				}
+				logger.info("Common Origin revision is {}", commonOriginRevision);
 			} else {
 				logger.warn("No SCMProcessor found for SCM type: {}", scm.getClass().getName());
 			}

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/AbstractBuildListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/AbstractBuildListenerOctaneImpl.java
@@ -136,28 +136,63 @@ public final class AbstractBuildListenerOctaneImpl extends RunListener<AbstractB
 					.setDuration(build.getDuration())
 					.setTestResultExpected(hasTests)
 					.setEnvironmentOutputtedParameters(OutputEnvironmentParametersHelper.getOutputEnvironmentParams(build));
-			CommonOriginRevision commonOriginRevision = getCommonOriginRevision(build);
-			if (commonOriginRevision != null) {
-				event
-						.setCommonHashId(commonOriginRevision.revision)
-						.setBranchName(commonOriginRevision.branch);
-			}
+
+			setCommonHashOnEvent(event, getCommonOriginRevision(build), build.getFullDisplayName());
+
 			CIJenkinsServicesImpl.publishEventToRelevantClients(event);
 		} catch (Throwable throwable) {
-			logger.error("failed to build and/or dispatch FINISHED event for " + build, throwable);
+			logger.error("failed to build and/or dispatch FINISHED event for {}", build, throwable);
 		}
 	}
 
+	/**
+	 * Extracts the common origin revision (merge-base) for an AbstractBuild.
+	 *
+	 * @param build the build to process
+	 * @return CommonOriginRevision containing branch and revision info, or null if unable to extract
+	 */
 	private CommonOriginRevision getCommonOriginRevision(AbstractBuild build) {
 		CommonOriginRevision commonOriginRevision = null;
 		SCM scm = build.getProject().getScm();
 		if (scm != null) {
+			logger.debug("SCM found for AbstractBuild: {}", scm.getClass().getName());
 			SCMProcessor scmProcessor = SCMProcessors.getAppropriate(scm.getClass().getName());
 			if (scmProcessor != null) {
+				logger.debug("SCMProcessor found: {}, calling getCommonOriginRevision", scmProcessor.getClass().getName());
 				commonOriginRevision = scmProcessor.getCommonOriginRevision(build);
+				if (commonOriginRevision != null) {
+					logger.debug("Common origin revision calculated - branch: {}, revision: {}", commonOriginRevision.branch, commonOriginRevision.revision);
+				} else {
+					logger.warn("SCMProcessor returned null for common origin revision");
+				}
+			} else {
+				logger.warn("No SCMProcessor found for SCM type: {}", scm.getClass().getName());
 			}
+		} else {
+			logger.debug("No SCM configured for build: {}", build.getFullDisplayName());
 		}
 		return commonOriginRevision;
+	}
+
+	/**
+	 * Sets the common hash ID and branch name on a CI event if valid.
+	 * Logs appropriate warnings if the common origin revision is invalid.
+	 *
+	 * @param event the CI event to update
+	 * @param commonOriginRevision the common origin revision data
+	 * @param buildDisplayName display name of the build for logging
+	 */
+	private void setCommonHashOnEvent(CIEvent event, CommonOriginRevision commonOriginRevision, String buildDisplayName) {
+		if (commonOriginRevision != null) {
+			if (commonOriginRevision.revision != null && !commonOriginRevision.revision.isEmpty()) {
+				event
+						.setCommonHashId(commonOriginRevision.revision)
+						.setBranchName(commonOriginRevision.branch);
+				logger.debug("Common hash set for build: {} (branch: {})", commonOriginRevision.revision, commonOriginRevision.branch);
+			} else {
+				logger.warn("Common origin revision object exists but revision is null/empty for build: {}", buildDisplayName);
+			}
+		}
 	}
 
 	//  TODO: https://issues.jenkins-ci.org/browse/JENKINS-53410

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
@@ -67,6 +67,7 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import java.lang.reflect.Method;
 
 import java.util.HashSet;
 import java.util.List;
@@ -190,8 +191,6 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 			SCM scm = extractScmFromJob(jobParent);
 			if (scm != null) {
 				return processScmForCommonOrigin(run, scm);
-			} else {
-				logger.warn("No SCM found for job: {} - common hash will not be sent", run.getFullDisplayName());
 			}
 		} catch (Exception e) {
 			logger.error("Failed to resolve common origin revision for pipeline run: {}", e.getMessage(), e);
@@ -212,18 +211,12 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 		if (scmProcessor != null) {
 			logger.debug("SCMProcessor found: {}, calling getCommonOriginRevision", scmProcessor.getClass().getName());
 			CommonOriginRevision commonOriginRevision = scmProcessor.getCommonOriginRevision(run);
+			logger.info("Common Origin revision is {}", commonOriginRevision);
 
-			if (commonOriginRevision != null) {
-				logger.debug("Common origin revision calculated - branch: {}, revision: {}",
-					commonOriginRevision.branch, commonOriginRevision.revision);
-			} else {
-				logger.warn("SCMProcessor returned null for common origin revision");
-			}
 			return commonOriginRevision;
-		} else {
-			logger.warn("No SCMProcessor found for SCM type: {}", scm.getClass().getName());
-			return null;
 		}
+
+		return null;
 	}
 
 	/**
@@ -243,53 +236,91 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 
 	/**
 	 * Directly extracts SCM from a job using various reflection strategies.
+	 *
+	 * @param job the job object to inspect
+	 * @return the SCM object, or null if not found
 	 */
 	private SCM extractScmDirectly(Object job) {
 		try {
-			// First, try the direct getScm() method (works for FreestyleJob, AbstractProject)
-			try {
-				java.lang.reflect.Method getSCMMethod = job.getClass().getMethod(METHOD_GET_SCM);
-				Object scmObj = getSCMMethod.invoke(job);
-				if (scmObj instanceof SCM) {
-					return (SCM) scmObj;
-				}
-			} catch (NoSuchMethodException e) {
-				logger.debug("Job {} does not have getScm() method, trying alternative approaches", job.getClass().getSimpleName());
+			SCM scm = tryExtractScmViaGetScm(job);
+			if (scm != null) {
+				return scm;
 			}
+		} catch (ReflectiveOperationException e) {
+			logger.debug("Job {} does not support getScm(), trying getDefinition().getScm()", job.getClass().getSimpleName());
+		}
 
-			// For Pipeline jobs with SCM, the definition is a CpsScmFlowDefinition
-			// Try to get definition from WorkflowJob
-			try {
-				java.lang.reflect.Method getDefinitionMethod = job.getClass().getMethod(METHOD_GET_DEFINITION);
-				Object definition = getDefinitionMethod.invoke(job);
-				if (definition != null) {
-					// Try to get SCM from the definition
-					java.lang.reflect.Method getSCMFromDefMethod = definition.getClass().getMethod(METHOD_GET_SCM);
-					Object scmObj = getSCMFromDefMethod.invoke(definition);
-					if (scmObj instanceof SCM) {
-						return (SCM) scmObj;
-					}
-				}
-			} catch (NoSuchMethodException e) {
-				logger.debug("Job {} does not have getDefinition().getScm() method, trying alternative approaches", job.getClass().getSimpleName());
+		try {
+			SCM scm = tryExtractScmViaDefinition(job);
+			if (scm != null) {
+				return scm;
 			}
+		} catch (ReflectiveOperationException e) {
+			logger.debug("Job {} does not support getDefinition().getScm(), trying getSCMs()", job.getClass().getSimpleName());
+		}
 
-			// Some workflow jobs expose SCMs as a collection rather than getScm()
-			try {
-				java.lang.reflect.Method getSCMsMethod = job.getClass().getMethod(METHOD_GET_SCMS);
-				Object scmsObj = getSCMsMethod.invoke(job);
-				if (scmsObj instanceof Collection<?>) {
-					for (Object scmObj : (Collection<?>) scmsObj) {
-						if (scmObj instanceof SCM) {
-							return (SCM) scmObj;
-						}
-					}
+		try {
+			return tryExtractScmViaScmsCollection(job);
+		} catch (ReflectiveOperationException e) {
+			logger.debug("Could not extract SCM from job {} using fallback strategies: {}", job.getClass().getSimpleName(), e.getMessage());
+		}
+		return null;
+	}
+
+	/**
+	 * Attempts to extract SCM by invoking {@code getScm()} directly on the job.
+	 *
+	 * @param job the job instance to inspect
+	 * @return extracted SCM, or null when the returned object is not an SCM
+	 * @throws ReflectiveOperationException when {@code getScm()} cannot be resolved or invoked
+	 */
+	private SCM tryExtractScmViaGetScm(Object job) throws ReflectiveOperationException {
+		Method getScmMethod = job.getClass().getMethod(METHOD_GET_SCM);
+		Object scmObj = getScmMethod.invoke(job);
+		if (scmObj instanceof SCM scm) {
+			return scm;
+		}
+		return null;
+	}
+
+	/**
+	 * Attempts to extract SCM from a pipeline definition via {@code getDefinition().getScm()}.
+	 *
+	 * @param job the job instance that may expose a pipeline definition
+	 * @return extracted SCM, or null when definition/scm is unavailable
+	 * @throws ReflectiveOperationException when reflection calls cannot be resolved or invoked
+	 */
+	private SCM tryExtractScmViaDefinition(Object job) throws ReflectiveOperationException {
+		Method getDefinitionMethod = job.getClass().getMethod(METHOD_GET_DEFINITION);
+		Object definition = getDefinitionMethod.invoke(job);
+		if (definition == null) {
+			return null;
+		}
+
+		Method getScmFromDefinitionMethod = definition.getClass().getMethod(METHOD_GET_SCM);
+		Object scmObj = getScmFromDefinitionMethod.invoke(definition);
+		if (scmObj instanceof SCM scm) {
+			return scm;
+		}
+		return null;
+	}
+
+	/**
+	 * Attempts to extract SCM from jobs exposing multiple SCMs via {@code getSCMs()}.
+	 *
+	 * @param job the job instance to inspect
+	 * @return first SCM found in the returned collection, or null when none is present
+	 * @throws ReflectiveOperationException when {@code getSCMs()} cannot be resolved or invoked
+	 */
+	private SCM tryExtractScmViaScmsCollection(Object job) throws ReflectiveOperationException {
+		Method getScmsMethod = job.getClass().getMethod(METHOD_GET_SCMS);
+		Object scmsObj = getScmsMethod.invoke(job);
+		if (scmsObj instanceof Collection<?> scmCollection) {
+			for (Object scmObj : scmCollection) {
+				if (scmObj instanceof SCM scm) {
+					return scm;
 				}
-			} catch (NoSuchMethodException e) {
-				logger.debug("Job {} does not have getSCMs() method, no more fallback options", job.getClass().getSimpleName());
 			}
-		} catch (Exception e) {
-			logger.debug("Could not extract SCM from job {}: {}", job.getClass().getSimpleName(), e.getMessage());
 		}
 		return null;
 	}
@@ -328,12 +359,13 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 	 */
 	private void setCommonHashOnEvent(CIEvent event, CommonOriginRevision commonOriginRevision, String runDisplayName) {
 		if (commonOriginRevision != null) {
-			if (commonOriginRevision.revision != null && !commonOriginRevision.revision.isEmpty()) {
+			String revision = commonOriginRevision.revision;
+			if (revision != null && !revision.isEmpty()) {
 				event
-						.setCommonHashId(commonOriginRevision.revision)
+						.setCommonHashId(revision)
 						.setBranchName(commonOriginRevision.branch);
 				logger.debug("Common hash set for pipeline run: {} (branch: {})",
-					commonOriginRevision.revision, commonOriginRevision.branch);
+					revision, commonOriginRevision.branch);
 			} else {
 				logger.warn("Common origin revision object exists but revision is null/empty for pipeline run: {}", runDisplayName);
 			}

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
@@ -51,10 +51,14 @@ import com.microfocus.application.automation.tools.octane.configuration.SDKBased
 import com.microfocus.application.automation.tools.octane.model.CIEventCausesFactory;
 import com.microfocus.application.automation.tools.octane.model.processors.parameters.ParameterProcessors;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
+import com.microfocus.application.automation.tools.octane.model.processors.scm.CommonOriginRevision;
+import com.microfocus.application.automation.tools.octane.model.processors.scm.SCMProcessor;
+import com.microfocus.application.automation.tools.octane.model.processors.scm.SCMProcessors;
 import com.microfocus.application.automation.tools.octane.tests.TestListener;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.Extension;
 import hudson.model.Result;
+import hudson.scm.SCM;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.actions.WarningAction;
@@ -67,6 +71,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Collection;
 
 /**
  * Octane's listener for WorkflowRun events
@@ -162,6 +167,133 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 		return run.getFullDisplayName();
 	}
 
+	// Reflection method names
+	private static final String METHOD_GET_DEFINITION = "getDefinition";
+	private static final String METHOD_GET_SCM = "getScm";
+	private static final String METHOD_GET_SCMS = "getSCMs";
+
+	/**
+	 * Extracts the common origin revision (merge-base) for a WorkflowRun.
+	 * This is used for code coverage comparison between branches in Octane.
+	 *
+	 * @param run the WorkflowRun to process
+	 * @return CommonOriginRevision containing branch and revision info, or null if unable to extract
+	 */
+	private CommonOriginRevision getCommonOriginRevision(WorkflowRun run) {
+		try {
+			Object jobParent = run.getParent();
+			if (jobParent == null) {
+				logger.warn("Job parent is null for run: {}", run.getFullDisplayName());
+				return null;
+			}
+
+			SCM scm = extractScmFromJob(jobParent);
+			if (scm != null) {
+				return processScmForCommonOrigin(run, scm);
+			} else {
+				logger.warn("No SCM found for job: {} - common hash will not be sent", run.getFullDisplayName());
+			}
+		} catch (Exception e) {
+			logger.error("Failed to resolve common origin revision for pipeline run: {}", e.getMessage(), e);
+		}
+		return null;
+	}
+
+	/**
+	 * Processes the SCM to extract common origin revision information.
+	 * @param run the WorkflowRun being processed
+	 * @param scm the SCM object associated with the run
+	 * @return CommonOriginRevision containing branch and revision info, or null if unable to extract
+	 */
+	private CommonOriginRevision processScmForCommonOrigin(WorkflowRun run, SCM scm) {
+		logger.debug("SCM found: {}, getting SCMProcessor", scm.getClass().getName());
+		SCMProcessor scmProcessor = SCMProcessors.getAppropriate(scm.getClass().getName());
+
+		if (scmProcessor != null) {
+			logger.debug("SCMProcessor found: {}, calling getCommonOriginRevision", scmProcessor.getClass().getName());
+			CommonOriginRevision commonOriginRevision = scmProcessor.getCommonOriginRevision(run);
+
+			if (commonOriginRevision != null) {
+				logger.debug("Common origin revision calculated - branch: {}, revision: {}",
+					commonOriginRevision.branch, commonOriginRevision.revision);
+			} else {
+				logger.warn("SCMProcessor returned null for common origin revision");
+			}
+			return commonOriginRevision;
+		} else {
+			logger.warn("No SCMProcessor found for SCM type: {}", scm.getClass().getName());
+			return null;
+		}
+	}
+
+	/**
+	 * Extracts SCM from a job object using reflection.
+	 * For both regular Pipeline jobs and MultiBranch Pipeline children, the parent is always
+	 * a WorkflowJob, so the same extraction strategies apply to both.
+	 *
+	 * @param job the job object (WorkflowJob, AbstractProject, etc.)
+	 * @return the SCM object, or null if not found
+	 */
+	private SCM extractScmFromJob(Object job) {
+		if (job == null) {
+			return null;
+		}
+		return extractScmDirectly(job);
+	}
+
+	/**
+	 * Directly extracts SCM from a job using various reflection strategies.
+	 */
+	private SCM extractScmDirectly(Object job) {
+		try {
+			// First, try the direct getScm() method (works for FreestyleJob, AbstractProject)
+			try {
+				java.lang.reflect.Method getSCMMethod = job.getClass().getMethod(METHOD_GET_SCM);
+				Object scmObj = getSCMMethod.invoke(job);
+				if (scmObj instanceof SCM) {
+					return (SCM) scmObj;
+				}
+			} catch (NoSuchMethodException e) {
+				logger.debug("Job {} does not have getScm() method, trying alternative approaches", job.getClass().getSimpleName());
+			}
+
+			// For Pipeline jobs with SCM, the definition is a CpsScmFlowDefinition
+			// Try to get definition from WorkflowJob
+			try {
+				java.lang.reflect.Method getDefinitionMethod = job.getClass().getMethod(METHOD_GET_DEFINITION);
+				Object definition = getDefinitionMethod.invoke(job);
+				if (definition != null) {
+					// Try to get SCM from the definition
+					java.lang.reflect.Method getSCMFromDefMethod = definition.getClass().getMethod(METHOD_GET_SCM);
+					Object scmObj = getSCMFromDefMethod.invoke(definition);
+					if (scmObj instanceof SCM) {
+						return (SCM) scmObj;
+					}
+				}
+			} catch (NoSuchMethodException e) {
+				logger.debug("Job {} does not have getDefinition().getScm() method, trying alternative approaches", job.getClass().getSimpleName());
+			}
+
+			// Some workflow jobs expose SCMs as a collection rather than getScm()
+			try {
+				java.lang.reflect.Method getSCMsMethod = job.getClass().getMethod(METHOD_GET_SCMS);
+				Object scmsObj = getSCMsMethod.invoke(job);
+				if (scmsObj instanceof Collection<?>) {
+					for (Object scmObj : (Collection<?>) scmsObj) {
+						if (scmObj instanceof SCM) {
+							return (SCM) scmObj;
+						}
+					}
+				}
+			} catch (NoSuchMethodException e) {
+				logger.debug("Job {} does not have getSCMs() method, no more fallback options", job.getClass().getSimpleName());
+			}
+		} catch (Exception e) {
+			logger.debug("Could not extract SCM from job {}: {}", job.getClass().getSimpleName(), e.getMessage());
+		}
+		return null;
+	}
+
 	private void sendPipelineFinishedEvent(WorkflowRun parentRun) {
 		workflowJobStarted.remove(getBuildKey(parentRun));
 		boolean hasTests = testListener.processBuild(parentRun);
@@ -179,7 +311,35 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 				.setCauses(CIEventCausesFactory.processCauses(parentRun))
 				.setTestResultExpected(hasTests)
 				.setEnvironmentOutputtedParameters(OutputEnvironmentParametersHelper.getOutputEnvironmentParams(parentRun));
+
+		// Set commonHashId and branchName for pipeline run comparison
+		setCommonHashOnEvent(event, getCommonOriginRevision(parentRun), parentRun.getFullDisplayName());
+
 		CIJenkinsServicesImpl.publishEventToRelevantClients(event);
+	}
+
+	/**
+	 * Sets the common hash ID and branch name on a CI event if valid.
+	 * Logs appropriate warnings if the common origin revision is invalid.
+	 *
+	 * @param event the CI event to update
+	 * @param commonOriginRevision the common origin revision data
+	 * @param runDisplayName display name of the run for logging
+	 */
+	private void setCommonHashOnEvent(CIEvent event, CommonOriginRevision commonOriginRevision, String runDisplayName) {
+		if (commonOriginRevision != null) {
+			if (commonOriginRevision.revision != null && !commonOriginRevision.revision.isEmpty()) {
+				event
+						.setCommonHashId(commonOriginRevision.revision)
+						.setBranchName(commonOriginRevision.branch);
+				logger.debug("Common hash set for pipeline run: {} (branch: {})",
+					commonOriginRevision.revision, commonOriginRevision.branch);
+			} else {
+				logger.warn("Common origin revision object exists but revision is null/empty for pipeline run: {}", runDisplayName);
+			}
+		} else {
+			logger.warn("Common origin revision is null for pipeline run: {} - common hash will not be sent to Octane", runDisplayName);
+		}
 	}
 
 	private void sendStageStartedEvent(StepStartNode stepStartNode) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
@@ -82,6 +82,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.*;
 
@@ -92,13 +93,7 @@ import java.util.*;
 class GitSCMProcessor implements SCMProcessor {
 	private static final Logger logger = SDKBasedLoggerProvider.getLogger(GitSCMProcessor.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
-	private static final List<String> PREFERRED_REMOTE_BRANCHES = Arrays.asList(
-			"refs/remotes/origin/master",
-			"refs/remotes/origin/main",
-			"refs/remotes/origin/develop",
-			"refs/remotes/origin/dev",
-			"refs/remotes/origin/trunk"
-	);
+	private static final String DEFAULT_REMOTE_BRANCH = "refs/remotes/origin/master";
 
 	// Reflection method names used for SCM extraction
 	private static final String METHOD_GET_DEFINITION = "getDefinition";
@@ -106,9 +101,10 @@ class GitSCMProcessor implements SCMProcessor {
 	private static final String METHOD_GET_SCMS = "getSCMs";
 
 	// Git ref path constants
-	private static final String REFS_REMOTES_ORIGIN_HEAD = "refs/remotes/origin/HEAD";
 	private static final String REFS_REMOTES_ORIGIN_PREFIX = "refs/remotes/origin/";
-	private static final String HEAD_SUFFIX = "/HEAD";
+
+	// Parameter name for user-specified default branch (used for merge-base calculation)
+	private static final String DEFAULT_BRANCH_PARAMETER = "DEFAULT_PROJECT_BRANCH";
 
 	@Override
 	public SCMData getSCMData(AbstractBuild build, SCM scm) {
@@ -161,10 +157,11 @@ class GitSCMProcessor implements SCMProcessor {
 
 		try {
 			FilePath workspace = getWorkspaceForRun(run);
-			String checkoutDirValue = getCheckoutDirForRun(run);
 
 			if (workspace != null) {
-				commonOriginRevision.revision = workspace.act(new FileContentCallable(checkoutDirValue));
+				String checkoutDirValue = getCheckoutDirForRun(run);
+				String defaultBranch = extractDefaultBranchParameter(run);
+				commonOriginRevision.revision = workspace.act(new FileContentCallable(checkoutDirValue, defaultBranch));
 				logger.debug("most recent common revision resolved to {} (branch: {})", commonOriginRevision.revision, commonOriginRevision.branch);
 			} else {
 				logger.warn("Workspace is null for run {}, cannot calculate common origin revision", run.getFullDisplayName());
@@ -191,25 +188,25 @@ class GitSCMProcessor implements SCMProcessor {
 	 * Gets the checkout directory for a given run, handling both AbstractBuild and WorkflowRun types.
 	 */
 	private String getCheckoutDirForRun(Run run) {
+		String checkoutDir = StringUtils.EMPTY;
+
 		if (run instanceof AbstractBuild abstractBuild) {
-			String checkoutDir = getCheckoutDir(abstractBuild);
+			checkoutDir = getCheckoutDir(abstractBuild);
 			logger.debug("AbstractBuild checkoutDir: '{}'", checkoutDir);
-			return checkoutDir;
 		} else if (run instanceof WorkflowRun workflowRun) {
 			SCM scm = extractScmFromRun(run);
-			String checkoutDir = scm != null ? getCheckoutDirForWorkflowRun(workflowRun, scm) : "";
+			checkoutDir = scm != null ? getCheckoutDirForWorkflowRun(workflowRun, scm) : StringUtils.EMPTY;
 			logger.debug("WorkflowRun checkoutDir: '{}', SCM: {}", checkoutDir, scm != null ? scm.getClass().getSimpleName() : "null");
-			return checkoutDir;
 		}
-		return "";
+
+		return checkoutDir;
 	}
 
 	private SCMData extractSCMData(Run run, SCM scm, List<ChangeLogSet<? extends ChangeLogSet.Entry>> changes) {
-		if (!(scm instanceof GitSCM)) {
+		if (!(scm instanceof GitSCM gitData)) {
 			throw new IllegalArgumentException("GitSCM type of SCM was expected here, found '" + scm.getClass().getName() + "'");
 		}
 
-		GitSCM gitData = (GitSCM) scm;
 		SCMRepository repository;
 		List<SCMCommit> tmpCommits;
 		String builtRevId = null;
@@ -248,6 +245,32 @@ class GitSCMProcessor implements SCMProcessor {
 	}
 
 	/**
+	 * Extracts the user-specified default branch parameter from the run.
+	 * This branch is used as the base for merge-base calculation (common ancestor).
+	 * Works for both AbstractBuild and WorkflowRun.
+	 *
+	 * @param run the Jenkins run
+	 * @return the default branch name, or null if not specified
+	 */
+	private String extractDefaultBranchParameter(Run run) {
+		try {
+			ParametersAction parameterAction = run.getAction(ParametersAction.class);
+			if (parameterAction != null) {
+				ParameterValue pv = parameterAction.getParameter(DEFAULT_BRANCH_PARAMETER);
+				if (pv != null && pv.getValue() instanceof String branch) {
+					if (StringUtils.isNotEmpty(branch)) {
+						logger.debug("Found {} parameter with value: {}", DEFAULT_BRANCH_PARAMETER, branch);
+						return branch.trim();
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.debug("Failed to extract {} parameter: {}", DEFAULT_BRANCH_PARAMETER, e.getMessage());
+		}
+		return null;
+	}
+
+	/**
 	 * Extracts SCM from a Run object, supporting both AbstractBuild and WorkflowRun.
 	 *
 	 * @param run the Jenkins run
@@ -272,45 +295,66 @@ class GitSCMProcessor implements SCMProcessor {
 		}
 
 		try {
-			// Try to get SCM from job definition (CpsScmFlowDefinition)
-			java.lang.reflect.Method getDefinitionMethod = jobParent.getClass().getMethod(METHOD_GET_DEFINITION);
-			Object definition = getDefinitionMethod.invoke(jobParent);
-			if (definition != null) {
-				java.lang.reflect.Method getSCMMethod = definition.getClass().getMethod(METHOD_GET_SCM);
-				Object scmObj = getSCMMethod.invoke(definition);
-				if (scmObj instanceof SCM) {
-					return (SCM) scmObj;
-				}
+			SCM scm = tryExtractScmViaDefinition(jobParent);
+			if (scm != null) {
+				return scm;
 			}
-		} catch (Exception e) {
+		} catch (ReflectiveOperationException e) {
 			logger.debug("Could not extract SCM from WorkflowRun definition: {}", e.getMessage());
 		}
 
-		// Some workflow jobs expose SCMs as a collection instead of a single getScm()
 		try {
-			java.lang.reflect.Method getSCMsMethod = jobParent.getClass().getMethod(METHOD_GET_SCMS);
-			Object scmsObj = getSCMsMethod.invoke(jobParent);
-			if (scmsObj instanceof Collection<?>) {
-				for (Object scmObj : (Collection<?>) scmsObj) {
-					if (scmObj instanceof SCM) {
-						return (SCM) scmObj;
-					}
-				}
+			SCM scm = tryExtractScmViaScmsCollection(jobParent);
+			if (scm != null) {
+				return scm;
 			}
-		} catch (Exception e) {
+		} catch (ReflectiveOperationException e) {
 			logger.debug("Could not extract SCM collection from WorkflowRun parent: {}", e.getMessage());
 		}
 
 		if (!JobProcessorFactory.WORKFLOW_MULTI_BRANCH_JOB_NAME.equals(jobParent.getClass().getName())) {
 			try {
-				java.lang.reflect.Method getSCMMethod = jobParent.getClass().getMethod(METHOD_GET_SCM);
-				Object scmObj = getSCMMethod.invoke(jobParent);
-				if (scmObj instanceof SCM) {
-					return (SCM) scmObj;
-				}
-			} catch (Exception e) {
+				return tryExtractScmViaDirectGetScm(jobParent);
+			} catch (ReflectiveOperationException e) {
 				logger.debug("Could not extract SCM using direct getScm fallback: {}", e.getMessage());
 			}
+		}
+		return null;
+	}
+
+	private SCM tryExtractScmViaDefinition(Object jobParent) throws ReflectiveOperationException {
+		Method getDefinitionMethod = jobParent.getClass().getMethod(METHOD_GET_DEFINITION);
+		Object definition = getDefinitionMethod.invoke(jobParent);
+		if (definition == null) {
+			return null;
+		}
+
+		Method getSCMMethod = definition.getClass().getMethod(METHOD_GET_SCM);
+		Object scmObj = getSCMMethod.invoke(definition);
+		if (scmObj instanceof SCM scm) {
+			return scm;
+		}
+		return null;
+	}
+
+	private SCM tryExtractScmViaScmsCollection(Object jobParent) throws ReflectiveOperationException {
+		Method getSCMsMethod = jobParent.getClass().getMethod(METHOD_GET_SCMS);
+		Object scmsObj = getSCMsMethod.invoke(jobParent);
+		if (scmsObj instanceof Collection<?> scmCollection) {
+			for (Object scmObj : scmCollection) {
+				if (scmObj instanceof SCM scm) {
+					return scm;
+				}
+			}
+		}
+		return null;
+	}
+
+	private SCM tryExtractScmViaDirectGetScm(Object jobParent) throws ReflectiveOperationException {
+		Method getSCMMethod = jobParent.getClass().getMethod(METHOD_GET_SCM);
+		Object scmObj = getSCMMethod.invoke(jobParent);
+		if (scmObj instanceof SCM scm) {
+			return scm;
 		}
 		return null;
 	}
@@ -324,16 +368,13 @@ class GitSCMProcessor implements SCMProcessor {
 			return null;
 		}
 
-		String rawBranchName = branches.get(0).toString();
-		if (rawBranchName == null) {
-			return null;
-		}
+		String rawBranchName = branches.stream().findFirst().toString();
 
-		// Handle parameterized branch names like ${BRANCH_NAME}
+        // Handle parameterized branch names like ${BRANCH_NAME}
 		if (rawBranchName.startsWith("${") && rawBranchName.endsWith("}")) {
 			String param = rawBranchName.substring(2, rawBranchName.length() - 1);
-			if (run instanceof AbstractBuild) {
-				Object value = ((AbstractBuild<?, ?>) run).getBuildVariables().get(param);
+			if (run instanceof AbstractBuild runObj) {
+				Object value = runObj.getBuildVariables().get(param);
 				return value != null ? value.toString() : param;
 			}
 			return param;
@@ -468,9 +509,11 @@ class GitSCMProcessor implements SCMProcessor {
 
 	private static final class FileContentCallable extends MasterToSlaveFileCallable<String> {
 		private final String checkoutDir;
+		private final String userDefaultBranch;
 
-		private FileContentCallable(String checkoutDir) {
+		private FileContentCallable(String checkoutDir, String userDefaultBranch) {
 			this.checkoutDir = checkoutDir;
+			this.userDefaultBranch = userDefaultBranch;
 		}
 
 		@Override
@@ -537,103 +580,52 @@ class GitSCMProcessor implements SCMProcessor {
 		/**
 		 * Tries to find the default remote branch in the repository.
 		 * Strategy:
-		 * 1. Try common branch names (master/main/develop/dev/trunk)
-		 * 2. Use symbolic ref from origin/HEAD if available
-		 * 3. Fallback to any concrete origin/* remote-tracking branch
-		 *
-		 * Note: this uses JGit refs instead of direct filesystem reads, so it also works
-		 * when refs are packed and not present as loose files under .git/refs.
+		 * 0. User-specified default branch parameter (DEFAULT_PROJECT_BRANCH job parameter)
+		 * 1. Fallback to refs/remotes/origin/master
 		 *
 		 * @param repo the Git repository
 		 * @return the ref name of the default remote branch, or null if not found
 		 */
 		private String findDefaultRemoteBranch(Repository repo) {
-			// Strategy 1: Try preferred branch names
-			String preferredBranch = tryFindPreferredRemoteBranch(repo);
-			if (preferredBranch != null) {
-				return preferredBranch;
-			}
-
-			// Strategy 2: Try origin/HEAD symbolic ref
-			String originHeadTarget = tryFindFromOriginHead(repo);
-			if (originHeadTarget != null) {
-				return originHeadTarget;
-			}
-
-			// Strategy 3: Fallback to any origin/* branch
-			return tryFindAnyOriginBranch(repo);
-		}
-
-		/**
-		 * Tries to find a branch from the predefined list of preferred branch names.
-		 *
-		 * @param repo the Git repository
-		 * @return the ref name if found, null otherwise
-		 */
-		private String tryFindPreferredRemoteBranch(Repository repo) {
-			for (String refName : PREFERRED_REMOTE_BRANCHES) {
-				if (refExists(repo, refName)) {
-					logger.debug("Using preferred remote branch for merge-base: {}", refName);
-					return refName;
+			// Strategy 0: User-specified default branch parameter (HIGHEST PRIORITY)
+			if (StringUtils.isNotEmpty(userDefaultBranch)) {
+				String resolvedBranch = resolveUserDefaultBranch(repo, userDefaultBranch);
+				if (resolvedBranch != null) {
+					return resolvedBranch;
 				}
+				logger.warn("User-specified default branch '{}' not found, falling back to master", userDefaultBranch);
 			}
+
+			// Strategy 1: Fallback to master
+			if (refExists(repo, DEFAULT_REMOTE_BRANCH)) {
+				logger.debug("Using default remote branch for merge-base: {}", DEFAULT_REMOTE_BRANCH);
+				return DEFAULT_REMOTE_BRANCH;
+			}
+
 			return null;
 		}
 
 		/**
-		 * Tries to find the default branch by resolving the origin/HEAD symbolic reference.
+		 * Resolves user-specified default branch to a full Git ref.
 		 *
 		 * @param repo the Git repository
-		 * @return the target ref name if origin/HEAD exists and points to a valid branch, null otherwise
+		 * @param userBranch the user-specified branch name
+		 * @return the resolved full ref name, or null if not found
 		 */
-		private String tryFindFromOriginHead(Repository repo) {
-			try {
-				Ref originHeadRef = repo.exactRef(REFS_REMOTES_ORIGIN_HEAD);
-				if (originHeadRef != null && originHeadRef.isSymbolic() && originHeadRef.getTarget() != null) {
-					String targetRefName = originHeadRef.getTarget().getName();
-					if (targetRefName != null && targetRefName.startsWith(REFS_REMOTES_ORIGIN_PREFIX)
-							&& refExists(repo, targetRefName)) {
-						logger.debug("Using origin/HEAD target as merge-base reference: {}", targetRefName);
-						return targetRefName;
-					}
-				}
-			} catch (Exception e) {
-				logger.debug("Failed to resolve origin/HEAD symbolic ref: {}", e.getMessage());
+		private String resolveUserDefaultBranch(Repository repo, String userBranch) {
+			// Try as-is first
+			if (refExists(repo, userBranch)) {
+				logger.debug("Using user-specified default branch (exact match): {}", userBranch);
+				return userBranch;
 			}
-			return null;
-		}
 
-		/**
-		 * Fallback strategy: finds any origin/* remote-tracking branch.
-		 * Returns the first branch alphabetically.
-		 *
-		 * @param repo the Git repository
-		 * @return the first origin/* branch found (sorted alphabetically), or null if none exist
-		 */
-		private String tryFindAnyOriginBranch(Repository repo) {
-			try {
-				List<Ref> allRefs = repo.getRefDatabase().getRefs();
-				List<String> candidates = new ArrayList<>();
-
-				for (Ref ref : allRefs) {
-					String fullName = ref.getName();
-					if (fullName == null) {
-						continue;
-					}
-					if (fullName.startsWith(REFS_REMOTES_ORIGIN_PREFIX)
-							&& !fullName.endsWith(HEAD_SUFFIX)
-							&& refExists(repo, fullName)) {
-						candidates.add(fullName);
-					}
+			// Only try with prefix if it's a plain branch name (not already a full ref path)
+			if (!userBranch.startsWith("refs/")) {
+				String withPrefix = REFS_REMOTES_ORIGIN_PREFIX + userBranch;
+				if (refExists(repo, withPrefix)) {
+					logger.debug("Using user-specified default branch (resolved to): {}", withPrefix);
+					return withPrefix;
 				}
-
-				if (!candidates.isEmpty()) {
-					Collections.sort(candidates);
-					logger.debug("Using fallback remote branch for merge-base: {}", candidates.get(0));
-					return candidates.get(0);
-				}
-			} catch (Exception e) {
-				logger.debug("Failed to enumerate origin/* refs: {}", e.getMessage());
 			}
 
 			return null;
@@ -644,8 +636,8 @@ class GitSCMProcessor implements SCMProcessor {
 				return repo.resolve(refName) != null;
 			} catch (Exception e) {
 				logger.debug("Failed to resolve ref {}: {}", refName, e.getMessage());
-				return false;
 			}
+			return false;
 		}
 	}
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
@@ -42,6 +42,8 @@ import com.hp.octane.integrations.dto.scm.impl.LineRange;
 import com.hp.octane.integrations.dto.scm.impl.RevisionsMap;
 import com.hp.octane.integrations.dto.scm.impl.SCMFileBlameImpl;
 import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
+import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
+import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.FilePath;
 import hudson.model.*;
 import hudson.plugins.git.Branch;
@@ -70,6 +72,7 @@ import org.eclipse.jgit.errors.NoMergeBaseException;
 import org.eclipse.jgit.internal.JGitText;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -89,7 +92,23 @@ import java.util.*;
 class GitSCMProcessor implements SCMProcessor {
 	private static final Logger logger = SDKBasedLoggerProvider.getLogger(GitSCMProcessor.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
-	private static final String MASTER = "refs/remotes/origin/master";
+	private static final List<String> PREFERRED_REMOTE_BRANCHES = Arrays.asList(
+			"refs/remotes/origin/master",
+			"refs/remotes/origin/main",
+			"refs/remotes/origin/develop",
+			"refs/remotes/origin/dev",
+			"refs/remotes/origin/trunk"
+	);
+
+	// Reflection method names used for SCM extraction
+	private static final String METHOD_GET_DEFINITION = "getDefinition";
+	private static final String METHOD_GET_SCM = "getScm";
+	private static final String METHOD_GET_SCMS = "getSCMs";
+
+	// Git ref path constants
+	private static final String REFS_REMOTES_ORIGIN_HEAD = "refs/remotes/origin/HEAD";
+	private static final String REFS_REMOTES_ORIGIN_PREFIX = "refs/remotes/origin/";
+	private static final String HEAD_SUFFIX = "/HEAD";
 
 	@Override
 	public SCMData getSCMData(AbstractBuild build, SCM scm) {
@@ -129,26 +148,60 @@ class GitSCMProcessor implements SCMProcessor {
 		return extractSCMData(run, scm, run.getChangeSets());
 	}
 
+	/**
+	 * Calculates the common origin revision (merge-base) between the current branch and the default remote branch.
+	 *
+	 * @param run the Jenkins run (supports both AbstractBuild and WorkflowRun)
+	 * @return CommonOriginRevision containing the branch name and common hash ID
+	 */
 	@Override
 	public CommonOriginRevision getCommonOriginRevision(final Run run) {
-		//for phase 1 this is hard coded since its not possible to calculate it, and configuration from outside will complicate the feature
-		//so for this phase we keep it hardcoded.
 		CommonOriginRevision commonOriginRevision = new CommonOriginRevision();
 		commonOriginRevision.branch = getBranchName(run);
 
 		try {
-			final AbstractBuild abstractBuild = (AbstractBuild) run;
-			FilePath workspace = ((AbstractBuild) run).getWorkspace();
-			if (workspace != null) {
-				commonOriginRevision.revision = workspace.act(new FileContentCallable(getCheckoutDir(abstractBuild)));
+			FilePath workspace = getWorkspaceForRun(run);
+			String checkoutDirValue = getCheckoutDirForRun(run);
 
+			if (workspace != null) {
+				commonOriginRevision.revision = workspace.act(new FileContentCallable(checkoutDirValue));
+				logger.debug("most recent common revision resolved to {} (branch: {})", commonOriginRevision.revision, commonOriginRevision.branch);
+			} else {
+				logger.warn("Workspace is null for run {}, cannot calculate common origin revision", run.getFullDisplayName());
 			}
-			logger.debug("most recent common revision resolved to " + commonOriginRevision.revision + " (branch: " + commonOriginRevision.branch + ")");
 		} catch (Exception e) {
 			logger.error("failed to resolve most recent common revision : " + e.getClass().getName() + " - " + e.getMessage());
-			return commonOriginRevision;
 		}
 		return commonOriginRevision;
+	}
+
+	/**
+	 * Gets the workspace for a given run, handling both AbstractBuild and WorkflowRun types.
+	 */
+	private FilePath getWorkspaceForRun(Run run) {
+		if (run instanceof AbstractBuild abstractBuild) {
+			return abstractBuild.getWorkspace();
+		} else if (run instanceof WorkflowRun workflowRun) {
+			return BuildHandlerUtils.getWorkspace(workflowRun);
+		}
+		return null;
+	}
+
+	/**
+	 * Gets the checkout directory for a given run, handling both AbstractBuild and WorkflowRun types.
+	 */
+	private String getCheckoutDirForRun(Run run) {
+		if (run instanceof AbstractBuild abstractBuild) {
+			String checkoutDir = getCheckoutDir(abstractBuild);
+			logger.debug("AbstractBuild checkoutDir: '{}'", checkoutDir);
+			return checkoutDir;
+		} else if (run instanceof WorkflowRun workflowRun) {
+			SCM scm = extractScmFromRun(run);
+			String checkoutDir = scm != null ? getCheckoutDirForWorkflowRun(workflowRun, scm) : "";
+			logger.debug("WorkflowRun checkoutDir: '{}', SCM: {}", checkoutDir, scm != null ? scm.getClass().getSimpleName() : "null");
+			return checkoutDir;
+		}
+		return "";
 	}
 
 	private SCMData extractSCMData(Run run, SCM scm, List<ChangeLogSet<? extends ChangeLogSet.Entry>> changes) {
@@ -175,28 +228,123 @@ class GitSCMProcessor implements SCMProcessor {
 				.setCommits(tmpCommits);
 	}
 
+	/**
+	 * Extracts the branch name from the run's SCM configuration.
+	 *
+	 * @param r the Jenkins run
+	 * @return the branch name, or null if unable to extract
+	 */
 	private String getBranchName(Run r) {
 		try {
-			SCM scm = ((AbstractBuild) r).getProject().getScm();
-			GitSCM git = (GitSCM) scm;
-			List<BranchSpec> branches = git.getBranches();
-			String rawBranchName = branches.get(0).toString();
-			if (rawBranchName != null && rawBranchName.startsWith("${") && rawBranchName.endsWith("}")) {
-				String param = rawBranchName.substring(2, rawBranchName.length() - 1);
-				if (((AbstractBuild) r).getBuildVariables().get(param) != null) {
-					return ((AbstractBuild) r).getBuildVariables().get(param).toString();
-				} else {
-					return param;
-				}
+			SCM scm = extractScmFromRun(r);
+
+			if (scm instanceof GitSCM git) {
+				return extractBranchFromGitSCM(git, r);
 			}
-			if (rawBranchName != null && rawBranchName.startsWith("*/")) {
-				return rawBranchName.substring(2);
-			}
-			return rawBranchName; //trunk the '*/' from the '*/<branch name>' in order to get clean branch name
 		} catch (Exception e) {
 			logger.error("failed to extract branch name", e);
 		}
 		return null;
+	}
+
+	/**
+	 * Extracts SCM from a Run object, supporting both AbstractBuild and WorkflowRun.
+	 *
+	 * @param run the Jenkins run
+	 * @return the SCM object, or null if not found
+	 */
+	private SCM extractScmFromRun(Run run) {
+		if (run instanceof AbstractBuild abstractBuild) {
+			return abstractBuild.getProject().getScm();
+		} else if (run instanceof WorkflowRun workflowRun) {
+			return extractScmFromWorkflowRun(workflowRun);
+		}
+		return null;
+	}
+
+	/**
+	 * Extracts SCM from a WorkflowRun using reflection.
+	 */
+	private SCM extractScmFromWorkflowRun(WorkflowRun workflowRun) {
+		Object jobParent = workflowRun.getParent();
+		if (jobParent == null) {
+			return null;
+		}
+
+		try {
+			// Try to get SCM from job definition (CpsScmFlowDefinition)
+			java.lang.reflect.Method getDefinitionMethod = jobParent.getClass().getMethod(METHOD_GET_DEFINITION);
+			Object definition = getDefinitionMethod.invoke(jobParent);
+			if (definition != null) {
+				java.lang.reflect.Method getSCMMethod = definition.getClass().getMethod(METHOD_GET_SCM);
+				Object scmObj = getSCMMethod.invoke(definition);
+				if (scmObj instanceof SCM) {
+					return (SCM) scmObj;
+				}
+			}
+		} catch (Exception e) {
+			logger.debug("Could not extract SCM from WorkflowRun definition: {}", e.getMessage());
+		}
+
+		// Some workflow jobs expose SCMs as a collection instead of a single getScm()
+		try {
+			java.lang.reflect.Method getSCMsMethod = jobParent.getClass().getMethod(METHOD_GET_SCMS);
+			Object scmsObj = getSCMsMethod.invoke(jobParent);
+			if (scmsObj instanceof Collection<?>) {
+				for (Object scmObj : (Collection<?>) scmsObj) {
+					if (scmObj instanceof SCM) {
+						return (SCM) scmObj;
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.debug("Could not extract SCM collection from WorkflowRun parent: {}", e.getMessage());
+		}
+
+		if (!JobProcessorFactory.WORKFLOW_MULTI_BRANCH_JOB_NAME.equals(jobParent.getClass().getName())) {
+			try {
+				java.lang.reflect.Method getSCMMethod = jobParent.getClass().getMethod(METHOD_GET_SCM);
+				Object scmObj = getSCMMethod.invoke(jobParent);
+				if (scmObj instanceof SCM) {
+					return (SCM) scmObj;
+				}
+			} catch (Exception e) {
+				logger.debug("Could not extract SCM using direct getScm fallback: {}", e.getMessage());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Extracts the branch name from a GitSCM configuration, resolving parameters if needed.
+	 */
+	private String extractBranchFromGitSCM(GitSCM git, Run run) {
+		List<BranchSpec> branches = git.getBranches();
+		if (branches == null || branches.isEmpty()) {
+			return null;
+		}
+
+		String rawBranchName = branches.get(0).toString();
+		if (rawBranchName == null) {
+			return null;
+		}
+
+		// Handle parameterized branch names like ${BRANCH_NAME}
+		if (rawBranchName.startsWith("${") && rawBranchName.endsWith("}")) {
+			String param = rawBranchName.substring(2, rawBranchName.length() - 1);
+			if (run instanceof AbstractBuild) {
+				Object value = ((AbstractBuild<?, ?>) run).getBuildVariables().get(param);
+				return value != null ? value.toString() : param;
+			}
+			return param;
+		}
+
+		// Remove '*/' prefix from branch names like '*/master'
+		if (rawBranchName.startsWith("*/")) {
+			return rawBranchName.substring(2);
+		}
+
+		return rawBranchName;
 	}
 
     private static String getCheckoutDir(AbstractBuild r) {
@@ -208,6 +356,33 @@ class GitSCMProcessor implements SCMProcessor {
             }
         }
         return "";
+	}
+
+	/**
+	 * Extracts the checkout directory for WorkflowRun (Pipeline jobs).
+	 * For Pipeline jobs, we need to get the SCM from the job definition.
+	 *
+	 * @param run the WorkflowRun instance
+	 * @param scm the SCM configuration
+	 * @return the checkout directory path, or empty string if not configured
+	 */
+	private static String getCheckoutDirForWorkflowRun(WorkflowRun run, SCM scm) {
+		try {
+			if (scm instanceof GitSCM gitSCM) {
+				DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions = gitSCM.getExtensions();
+				if (extensions != null) {
+					RelativeTargetDirectory relativeTargetDirectory = extensions.get(RelativeTargetDirectory.class);
+					if (relativeTargetDirectory != null && relativeTargetDirectory.getRelativeTargetDir() != null) {
+						String checkoutDir = relativeTargetDirectory.getRelativeTargetDir();
+						logger.debug("Checkout directory found for WorkflowRun: {}", checkoutDir);
+						return checkoutDir;
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.debug("Could not extract checkout directory for WorkflowRun: {}", e.getMessage());
+		}
+		return StringUtils.EMPTY;
 	}
 
 	private SCMRepository getRepository(Run run, GitSCM gitData) {
@@ -318,7 +493,13 @@ class GitSCMProcessor implements SCMProcessor {
 						return "";
 					}
 
-					ObjectId resolveForMaster = repo.resolve(MASTER);
+					// Try to find the default remote branch
+					String defaultRemoteBranch = findDefaultRemoteBranch(repo);
+					if (defaultRemoteBranch == null) {
+						return "";
+					}
+
+					ObjectId resolveForMaster = repo.resolve(defaultRemoteBranch);
 					if (resolveForMaster == null) {
 						return "";
 					}
@@ -350,6 +531,120 @@ class GitSCMProcessor implements SCMProcessor {
 					}
 					return base.getId().getName();
 				}
+			}
+		}
+
+		/**
+		 * Tries to find the default remote branch in the repository.
+		 * Strategy:
+		 * 1. Try common branch names (master/main/develop/dev/trunk)
+		 * 2. Use symbolic ref from origin/HEAD if available
+		 * 3. Fallback to any concrete origin/* remote-tracking branch
+		 *
+		 * Note: this uses JGit refs instead of direct filesystem reads, so it also works
+		 * when refs are packed and not present as loose files under .git/refs.
+		 *
+		 * @param repo the Git repository
+		 * @return the ref name of the default remote branch, or null if not found
+		 */
+		private String findDefaultRemoteBranch(Repository repo) {
+			// Strategy 1: Try preferred branch names
+			String preferredBranch = tryFindPreferredRemoteBranch(repo);
+			if (preferredBranch != null) {
+				return preferredBranch;
+			}
+
+			// Strategy 2: Try origin/HEAD symbolic ref
+			String originHeadTarget = tryFindFromOriginHead(repo);
+			if (originHeadTarget != null) {
+				return originHeadTarget;
+			}
+
+			// Strategy 3: Fallback to any origin/* branch
+			return tryFindAnyOriginBranch(repo);
+		}
+
+		/**
+		 * Tries to find a branch from the predefined list of preferred branch names.
+		 *
+		 * @param repo the Git repository
+		 * @return the ref name if found, null otherwise
+		 */
+		private String tryFindPreferredRemoteBranch(Repository repo) {
+			for (String refName : PREFERRED_REMOTE_BRANCHES) {
+				if (refExists(repo, refName)) {
+					logger.debug("Using preferred remote branch for merge-base: {}", refName);
+					return refName;
+				}
+			}
+			return null;
+		}
+
+		/**
+		 * Tries to find the default branch by resolving the origin/HEAD symbolic reference.
+		 *
+		 * @param repo the Git repository
+		 * @return the target ref name if origin/HEAD exists and points to a valid branch, null otherwise
+		 */
+		private String tryFindFromOriginHead(Repository repo) {
+			try {
+				Ref originHeadRef = repo.exactRef(REFS_REMOTES_ORIGIN_HEAD);
+				if (originHeadRef != null && originHeadRef.isSymbolic() && originHeadRef.getTarget() != null) {
+					String targetRefName = originHeadRef.getTarget().getName();
+					if (targetRefName != null && targetRefName.startsWith(REFS_REMOTES_ORIGIN_PREFIX)
+							&& refExists(repo, targetRefName)) {
+						logger.debug("Using origin/HEAD target as merge-base reference: {}", targetRefName);
+						return targetRefName;
+					}
+				}
+			} catch (Exception e) {
+				logger.debug("Failed to resolve origin/HEAD symbolic ref: {}", e.getMessage());
+			}
+			return null;
+		}
+
+		/**
+		 * Fallback strategy: finds any origin/* remote-tracking branch.
+		 * Returns the first branch alphabetically.
+		 *
+		 * @param repo the Git repository
+		 * @return the first origin/* branch found (sorted alphabetically), or null if none exist
+		 */
+		private String tryFindAnyOriginBranch(Repository repo) {
+			try {
+				List<Ref> allRefs = repo.getRefDatabase().getRefs();
+				List<String> candidates = new ArrayList<>();
+
+				for (Ref ref : allRefs) {
+					String fullName = ref.getName();
+					if (fullName == null) {
+						continue;
+					}
+					if (fullName.startsWith(REFS_REMOTES_ORIGIN_PREFIX)
+							&& !fullName.endsWith(HEAD_SUFFIX)
+							&& refExists(repo, fullName)) {
+						candidates.add(fullName);
+					}
+				}
+
+				if (!candidates.isEmpty()) {
+					Collections.sort(candidates);
+					logger.debug("Using fallback remote branch for merge-base: {}", candidates.get(0));
+					return candidates.get(0);
+				}
+			} catch (Exception e) {
+				logger.debug("Failed to enumerate origin/* refs: {}", e.getMessage());
+			}
+
+			return null;
+		}
+
+		private boolean refExists(Repository repo, String refName) {
+			try {
+				return repo.resolve(refName) != null;
+			} catch (Exception e) {
+				logger.debug("Failed to resolve ref {}: {}", refName, e.getMessage());
+				return false;
 			}
 		}
 	}

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
@@ -258,9 +258,9 @@ class GitSCMProcessor implements SCMProcessor {
 			if (parameterAction != null) {
 				ParameterValue pv = parameterAction.getParameter(DEFAULT_BRANCH_PARAMETER);
 				if (pv != null && pv.getValue() instanceof String branch) {
-					if (StringUtils.isNotEmpty(branch)) {
+					if (StringUtils.isNotBlank(branch)) {
 						logger.debug("Found {} parameter with value: {}", DEFAULT_BRANCH_PARAMETER, branch);
-						return branch.trim();
+						return branch;
 					}
 				}
 			}
@@ -286,75 +286,94 @@ class GitSCMProcessor implements SCMProcessor {
 	}
 
 	/**
-	 * Extracts SCM from a WorkflowRun using reflection.
+	 * Extracts SCM from a WorkflowRun using reflection, trying multiple strategies.
+	 *
+	 * @param workflowRun the WorkflowRun instance
+	 * @return the SCM object if found, null otherwise
 	 */
 	private SCM extractScmFromWorkflowRun(WorkflowRun workflowRun) {
 		Object jobParent = workflowRun.getParent();
-		if (jobParent == null) {
-			return null;
+
+		SCM scm = tryExtractScmViaDefinition(jobParent);
+		if (scm != null) {
+			return scm;
 		}
 
+		scm = tryExtractScmViaScmsCollection(jobParent);
+		if (scm != null) {
+			return scm;
+		}
+
+		if (!JobProcessorFactory.WORKFLOW_MULTI_BRANCH_JOB_NAME.equals(jobParent.getClass().getName())) {
+			scm = tryExtractScmViaDirectGetScm(jobParent);
+		}
+
+		return scm;
+	}
+
+	/**
+	 * Attempts to extract SCM via job definition (getDefinition().getScm()).
+	 *
+	 * @param jobParent the job parent object
+	 * @return the SCM object if found, null otherwise
+	 */
+	private SCM tryExtractScmViaDefinition(Object jobParent) {
 		try {
-			SCM scm = tryExtractScmViaDefinition(jobParent);
-			if (scm != null) {
+			Method getDefinitionMethod = jobParent.getClass().getMethod(METHOD_GET_DEFINITION);
+			Object definition = getDefinitionMethod.invoke(jobParent);
+			if (definition == null) {
+				return null;
+			}
+
+			Method getSCMMethod = definition.getClass().getMethod(METHOD_GET_SCM);
+			Object scmObj = getSCMMethod.invoke(definition);
+			if (scmObj instanceof SCM scm) {
 				return scm;
 			}
 		} catch (ReflectiveOperationException e) {
 			logger.debug("Could not extract SCM from WorkflowRun definition: {}", e.getMessage());
 		}
+		return null;
+	}
 
+	/**
+	 * Attempts to extract SCM from SCMs collection (getSCMs()).
+	 *
+	 * @param jobParent the job parent object
+	 * @return the first SCM object found in the collection, null otherwise
+	 */
+	private SCM tryExtractScmViaScmsCollection(Object jobParent) {
 		try {
-			SCM scm = tryExtractScmViaScmsCollection(jobParent);
-			if (scm != null) {
-				return scm;
+			Method getSCMsMethod = jobParent.getClass().getMethod(METHOD_GET_SCMS);
+			Object scmsObj = getSCMsMethod.invoke(jobParent);
+			if (scmsObj instanceof Collection<?> scmCollection) {
+				for (Object scmObj : scmCollection) {
+					if (scmObj instanceof SCM scm) {
+						return scm;
+					}
+				}
 			}
 		} catch (ReflectiveOperationException e) {
 			logger.debug("Could not extract SCM collection from WorkflowRun parent: {}", e.getMessage());
 		}
+		return null;
+	}
 
-		if (!JobProcessorFactory.WORKFLOW_MULTI_BRANCH_JOB_NAME.equals(jobParent.getClass().getName())) {
-			try {
-				return tryExtractScmViaDirectGetScm(jobParent);
-			} catch (ReflectiveOperationException e) {
-				logger.debug("Could not extract SCM using direct getScm fallback: {}", e.getMessage());
+	/**
+	 * Attempts to extract SCM directly via getScm() method.
+	 *
+	 * @param jobParent the job parent object
+	 * @return the SCM object if found, null otherwise
+	 */
+	private SCM tryExtractScmViaDirectGetScm(Object jobParent) {
+		try {
+			Method getSCMMethod = jobParent.getClass().getMethod(METHOD_GET_SCM);
+			Object scmObj = getSCMMethod.invoke(jobParent);
+			if (scmObj instanceof SCM scm) {
+				return scm;
 			}
-		}
-		return null;
-	}
-
-	private SCM tryExtractScmViaDefinition(Object jobParent) throws ReflectiveOperationException {
-		Method getDefinitionMethod = jobParent.getClass().getMethod(METHOD_GET_DEFINITION);
-		Object definition = getDefinitionMethod.invoke(jobParent);
-		if (definition == null) {
-			return null;
-		}
-
-		Method getSCMMethod = definition.getClass().getMethod(METHOD_GET_SCM);
-		Object scmObj = getSCMMethod.invoke(definition);
-		if (scmObj instanceof SCM scm) {
-			return scm;
-		}
-		return null;
-	}
-
-	private SCM tryExtractScmViaScmsCollection(Object jobParent) throws ReflectiveOperationException {
-		Method getSCMsMethod = jobParent.getClass().getMethod(METHOD_GET_SCMS);
-		Object scmsObj = getSCMsMethod.invoke(jobParent);
-		if (scmsObj instanceof Collection<?> scmCollection) {
-			for (Object scmObj : scmCollection) {
-				if (scmObj instanceof SCM scm) {
-					return scm;
-				}
-			}
-		}
-		return null;
-	}
-
-	private SCM tryExtractScmViaDirectGetScm(Object jobParent) throws ReflectiveOperationException {
-		Method getSCMMethod = jobParent.getClass().getMethod(METHOD_GET_SCM);
-		Object scmObj = getSCMMethod.invoke(jobParent);
-		if (scmObj instanceof SCM scm) {
-			return scm;
+		} catch (ReflectiveOperationException e) {
+			logger.debug("Could not extract SCM using direct getScm fallback: {}", e.getMessage());
 		}
 		return null;
 	}


### PR DESCRIPTION
## Work Item
- Defect#[3121389](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3121389): It cannot compare custom pipeline to master pipeline because that common hash is not arrive from Jenkins CI plugin

## Description
- This PR fixes an issue where Jenkins Pipeline jobs (WorkflowRun) stopped sending common_hash to ALM Octane, which broke branch comparison in Octane Center. The issue was observed from 01/02/2026 and affected comparisons between custom/branch pipelines and their referral main pipeline.
- The fix updates common hash calculation for Pipeline runs by using the correct workspace resolution path and extracting the Git checkout directory from WorkflowRun SCM configuration. It also improves logging and adds validation before setting common_hash on the run-finish event payload.
- With this change, the CI plugin sends common_hash again for Pipeline run finish events, restoring branch comparison behavior in Octane Center. Freestyle behavior remains intact, while Pipeline and Multibranch scenarios now correctly support comparison against the referral pipeline.


Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [ ] Proper pull request title - concise and clear for others.
- [ ] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [ ] Proper Jira ticket - Number, Link in pull request description.
- [ ] The PR can is merged on your machine without any conflicts.
- [ ] The PR can is built on your machine without any (new) warnings.
- [ ] The PR passed sanity tests by you / QA / DevTest / Good Samaritan.
- [ ] Add unit tests with new features.
- [ ] If you added any dependency to the POM - Please update grount
