### PR TITLE
Defect #3259134: [Jenkins Plugin] Missing permission checks allow unauthorized Octane configuration and workspace enumeration

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/JellyUtils.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/JellyUtils.java
@@ -52,6 +52,7 @@ import hudson.model.Queue;
 import hudson.model.queue.Tasks;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -71,7 +72,34 @@ public class JellyUtils {
         return m;
     }
 
-    public static ListBoxModel fillWorkspaceModel(String configurationId, String workspaceId) {
+    /**
+     * Checks whether the caller is allowed to enumerate the Software Delivery Management
+     * configurations / workspaces.
+     * <p>
+     * When the request was made in the context of an item (i.e. the job configuration form that
+     * owns the field), {@link Item#CONFIGURE} is required - it is the permission that grants write
+     * access to a job, and therefore the permission required to legitimately pick a value for one
+     * of these fields. When no ancestor item is available (for example a direct
+     * {@code /descriptorByName/...} call, or the global Pipeline Syntax page), there is no object
+     * to authorize against, so {@link Jenkins#ADMINISTER} is required instead.
+     *
+     * @param project the ancestor item of the request, or {@code null} if there is none
+     * @return {@code true} if the current user may see the listing
+     */
+    public static boolean hasConfigurationReadPermission(Item project) {
+        if (project != null) {
+            return project.hasPermission(Item.CONFIGURE);
+        }
+        return Jenkins.get().hasPermission(Jenkins.ADMINISTER);
+    }
+
+    public static ListBoxModel fillWorkspaceModel(Item project, String configurationId, String workspaceId) {
+        //do not leak the workspace inventory - and do not issue the outbound authenticated
+        //call to the Octane server - to users that are not allowed to configure this item
+        if (!hasConfigurationReadPermission(project)) {
+            return new ListBoxModel();
+        }
+
         ListBoxModel m = createComboModelWithNoneValue();
         if (StringUtils.isNotEmpty(configurationId) && !NONE.equals(configurationId)) {
             try {
@@ -89,7 +117,13 @@ public class JellyUtils {
         return m;
     }
 
-    public static ListBoxModel fillConfigurationIdModel() {
+    public static ListBoxModel fillConfigurationIdModel(Item project) {
+        //do not leak the configured Octane instances (the caption contains the server location
+        //and shared space) to users that are not allowed to configure this item
+        if (!hasConfigurationReadPermission(project)) {
+            return new ListBoxModel();
+        }
+
         ListBoxModel m = createComboModelWithNoneValue();
 
         for (OctaneClient octaneClient : OctaneSDK.getClients()) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/actions/UFTTestDetectionPublisher.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/actions/UFTTestDetectionPublisher.java
@@ -65,6 +65,7 @@ import hudson.tasks.Recorder;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -330,12 +331,12 @@ public class UFTTestDetectionPublisher extends Recorder {
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
-        public ListBoxModel doFillConfigurationIdItems() {
-            return JellyUtils.fillConfigurationIdModel();
+        public ListBoxModel doFillConfigurationIdItems(@AncestorInPath Item project) {
+            return JellyUtils.fillConfigurationIdModel(project);
         }
 
-        public ListBoxModel doFillWorkspaceNameItems(@QueryParameter String configurationId, @QueryParameter(value = "workspaceName") String workspaceName) {
-            return JellyUtils.fillWorkspaceModel(configurationId, workspaceName);
+        public ListBoxModel doFillWorkspaceNameItems(@AncestorInPath Item project, @QueryParameter String configurationId, @QueryParameter(value = "workspaceName") String workspaceName) {
+            return JellyUtils.fillWorkspaceModel(project, configurationId, workspaceName);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/branches/BranchesPublisher.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/branches/BranchesPublisher.java
@@ -323,12 +323,12 @@ public class BranchesPublisher extends Recorder implements SimpleBuildStep {
             return true;
         }
 
-        public ListBoxModel doFillConfigurationIdItems() {
-            return JellyUtils.fillConfigurationIdModel();
+        public ListBoxModel doFillConfigurationIdItems(@AncestorInPath Item project) {
+            return JellyUtils.fillConfigurationIdModel(project);
         }
 
-        public ListBoxModel doFillWorkspaceIdItems(@QueryParameter String configurationId, @QueryParameter(value = "workspaceId") String workspaceId) {
-            return JellyUtils.fillWorkspaceModel(configurationId, workspaceId);
+        public ListBoxModel doFillWorkspaceIdItems(@AncestorInPath Item project, @QueryParameter String configurationId, @QueryParameter(value = "workspaceId") String workspaceId) {
+            return JellyUtils.fillWorkspaceModel(project, configurationId, workspaceId);
         }
 
         public String getDisplayName() {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/octaneExecution/ExecuteTestsInOctaneBuilder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/octaneExecution/ExecuteTestsInOctaneBuilder.java
@@ -68,6 +68,7 @@ import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -336,12 +337,12 @@ public class ExecuteTestsInOctaneBuilder extends Builder implements SimpleBuildS
             return m;
         }
 
-        public ListBoxModel doFillConfigurationIdItems() {
-            return JellyUtils.fillConfigurationIdModel();
+        public ListBoxModel doFillConfigurationIdItems(@AncestorInPath Item project) {
+            return JellyUtils.fillConfigurationIdModel(project);
         }
 
-        public ListBoxModel doFillWorkspaceIdItems(@QueryParameter String configurationId, @QueryParameter(value = "workspaceId") String workspaceId) {
-            return JellyUtils.fillWorkspaceModel(configurationId, workspaceId);
+        public ListBoxModel doFillWorkspaceIdItems(@AncestorInPath Item project, @QueryParameter String configurationId, @QueryParameter(value = "workspaceId") String workspaceId) {
+            return JellyUtils.fillWorkspaceModel(project, configurationId, workspaceId);
         }
 
     }

--- a/src/main/java/com/microfocus/application/automation/tools/octane/pullrequests/PullRequestPublisher.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/pullrequests/PullRequestPublisher.java
@@ -337,12 +337,12 @@ public class PullRequestPublisher extends Recorder implements SimpleBuildStep {
             return true;
         }
 
-        public ListBoxModel doFillConfigurationIdItems() {
-            return JellyUtils.fillConfigurationIdModel();
+        public ListBoxModel doFillConfigurationIdItems(@AncestorInPath Item project) {
+            return JellyUtils.fillConfigurationIdModel(project);
         }
 
-        public ListBoxModel doFillWorkspaceIdItems(@QueryParameter String configurationId, @QueryParameter(value = "workspaceId") String workspaceId) {
-            return JellyUtils.fillWorkspaceModel(configurationId, workspaceId);
+        public ListBoxModel doFillWorkspaceIdItems(@AncestorInPath Item project, @QueryParameter String configurationId, @QueryParameter(value = "workspaceId") String workspaceId) {
+            return JellyUtils.fillWorkspaceModel(project, configurationId, workspaceId);
         }
 
         public String getDisplayName() {


### PR DESCRIPTION
## Backlog Item
- Defect [#3259134](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3259134): [Jenkins Plugin] Missing permission checks allow unauthorized Octane configuration and workspace enumeration

## Description
- Fixed CWE-862 (Missing Authorization) in eight doFill* form-fill endpoints across the four Octane plugin descriptors (BranchesPublisher, PullRequestPublisher, ExecuteTestsInOctaneBuilder, UFTTestDetectionPublisher). Any authenticated user with Overall/Read could call these directly to enumerate configured Octane server URLs and workspaces with the workspace methods making live authenticated API calls to the Octane server. The fix gates all eight endpoints behind Item.CONFIGURE when a job context is present, or Jenkins.ADMINISTER when called without one (the reported attack path). 

Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [ ] Proper pull request title - concise and clear for others.
- [ ] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [ ] Proper Jira ticket - Number, Link in pull request description.
- [ ] The PR can is merged on your machine without any conflicts.
- [ ] The PR can is built on your machine without any (new) warnings.
- [ ] The PR passed sanity tests by you / QA / DevTest / Good Samaritan.
- [ ] Add unit tests with new features.
- [ ] If you added any dependency to the POM - Please update grount
