### PR TITLE
user story #3271070 - Update Jenkins version to use Spring 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>6.2116.v7501b_67dc517</version> <!-- TODO newer versions require an upgrade of the test harness -->
+        <version>6.2221.va_045130417c9</version>
         <relativePath />
     </parent>
 
@@ -73,13 +73,12 @@
         <concurrency>1</concurrency>
         <msbuild.exe>C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe</msbuild.exe>
         <msbuild.configuration>Release</msbuild.configuration>
-        <jenkins.baseline>2.504</jenkins.baseline>
+        <!-- 2.568.x is the first LTS line shipping Spring Framework 7 / Spring Security 7 -->
+        <jenkins.baseline>2.568</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <maven.exec.skip>false</maven.exec.skip>
         <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
         <hpi.bundledArtifacts>SVConfigurator,bcpg-jdk18on,bcpkix-jdk18on,bcprov-jdk18on,bcutil-jdk18on,commons-cli,commons-csv,commons-lang,integrations-dto,integrations-sdk,log4j-api,log4j-core,log4j-web,plugins-common,poi,tape,zip4j</hpi.bundledArtifacts>
-        <jenkins-test-harness.version>2545.va_5c4d760c7ef
-        </jenkins-test-harness.version> <!-- TODO newer versions than 2.55 require debugging an issue with open file handles -->
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.release>21</maven.compiler.release>
@@ -461,7 +460,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5983.v443959746f1f</version>
+                <version>7002.v028a_3607ddc8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
# Review: Jenkins baseline bump to 2.568.x (brings Spring Framework 7)

## Summary

Moves the plugin's Jenkins baseline from **2.504.3** to **LTS 2.568.3**, which is the first
LTS line that ships **Spring Framework 7** and **Spring Security 7**.

The change is confined to `pom.xml` (4 lines). No Java source changes were required.

## Why a baseline bump, and not a dependency bump

Spring is not declared anywhere in this repository. It is supplied by Jenkins core at
`provided` scope, so the only supported way to obtain Spring 7 is to move the core baseline.
Adding `org.springframework` dependencies directly would conflict with the version
Jenkins core loads at runtime.

Jenkins core adopted Spring 7 in weekly **2.556**; the first LTS carrying it is **2.568.3**.

## Changes in `pom.xml`

| Item | Before | After |
|---|---|---|
| Parent `org.jenkins-ci.plugins:plugin` | `6.2116.v7501b_67dc517` | `6.2221.va_045130417c9` |
| `jenkins.baseline` | `2.504` | `2.568` |
| Plugin BOM `bom-${jenkins.baseline}.x` | `5983.v443959746f1f` | `7002.v028a_3607ddc8` |
| `jenkins-test-harness.version` | pinned `2545.va_5c4d760c7ef` | removed (inherited from parent) |

`jenkins.version` is unchanged as an expression and now resolves to `2.568.3`.

### Note on the removed test-harness pin

The old pin carried a `TODO` about open file handles on newer versions. The pin was
incompatible with the new parent POM, and the inherited harness passes the suite, so the
stale pin and its `TODO` were dropped.

## Resulting dependency versions

| Dependency | Before | After |
|---|---|---|
| `org.springframework:spring-core` (and `-beans`, `-context`, `-aop`, `-expression`, `-web`) | 6.2.5 | **7.0.8** |
| `org.springframework.security:spring-security-core` (and `-web`, `-crypto`) | 6.4.4 | **7.1.0** |
| `org.eclipse.jetty:*` (test scope only) | 12.1.5 | 12.1.11 |
| `jakarta.xml.bind:jakarta.xml.bind-api` | 4.0.4 | 4.0.5 |
| `org.glassfish.jersey:*` | 3.1.11 | 3.1.11 (unchanged) |
| `jakarta.servlet:jakarta.servlet-api` | 5.0.0 | 5.0.0 (unchanged) |
| `jakarta.activation:jakarta.activation-api` | 2.1.4 | 2.1.4 (unchanged) |

All Spring and Jetty artifacts are `provided` or `test` scope and are not bundled in the HPI.

## Spring 7 requirements check

| Requirement | Status |
|---|---|
| Java 17 minimum | Met — project already compiles at release 21 |
| No pinned Spring versions in the build | Met — none are declared in this repo |
| No pinned Jakarta/Jersey versions | Met — all managed by the plugin BOM |

### Why Jersey and the Servlet API were deliberately left alone

Spring Framework 7's general baseline is Jakarta EE 11 (Servlet 6.1, Jetty EE11), but
**Jenkins core does not adopt that baseline**. Core still manages `jakarta.servlet-api` 5.0.0
and runs on Jetty 12 EE9, consuming only a subset of Spring. Forcing Jersey 4, Servlet 6.1,
or Jetty EE11 into this plugin would diverge from the runtime Jenkins actually provides and
would break it. Plugins must follow the core-provided dependency set.

## Reviewer checklist

- [ ] Confirm 2.568.3 is an acceptable minimum supported Jenkins version for this plugin's users.
- [ ] Confirm dropping the `jenkins-test-harness.version` pin is acceptable.
- [ ] Update any documentation or plugin metadata that states the minimum Jenkins version.
